### PR TITLE
Fix nah test splitting quoted shell arguments

### DIFF
--- a/src/nah/cli.py
+++ b/src/nah/cli.py
@@ -3,6 +3,7 @@
 import argparse
 import json
 import os
+import shlex
 import stat
 import sys
 from pathlib import Path
@@ -286,7 +287,7 @@ def cmd_test(args: argparse.Namespace) -> None:
         if not input_args:
             print("Error: nah test requires a command string", file=sys.stderr)
             raise SystemExit(1)
-        command = " ".join(input_args)
+        command = shlex.join(input_args)
         from nah.bash import classify_command
         result = classify_command(command)
 


### PR DESCRIPTION
## Problem

Running `nah test` on an ssh command with a quoted multi-statement payload gets misclassified:

```bash
nah test -- ssh user@example.com "cd /app && python deploy.py"
```

**Expected:** 1 stage — `ssh` with a quoted remote payload → `network_outbound`

**Actual:** 2 stages:
1. `ssh user@example.com cd /app` → `network_outbound`
2. `python deploy.py` → `unknown`

The `&&` inside the double-quoted string is treated as a top-level shell operator, so nah thinks you're running `python deploy.py` locally.

## Cause

`nah test` reconstructs the command string from argv using `" ".join()`, which drops quote boundaries. By the time argv reaches the CLI, the shell has already stripped the outer quotes — so the `&&` inside the payload becomes visible as a bare operator when re-parsed by `shlex.split()`.

## Fix

Replace `" ".join(input_args)` with `shlex.join(input_args)` (stdlib, Python 3.8+), which re-quotes any arguments containing shell metacharacters before `shlex.split()` sees them.

## Test plan
- [x] Verified with the repro command above — single stage, `network_outbound`
- [x] 1896 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)