### PR TITLE
feat: emit active allow decisions and add gh api flag classifier

### DIFF
--- a/src/nah/cli.py
+++ b/src/nah/cli.py
@@ -61,10 +61,10 @@ try:
     main()
     sys.stdout = _REAL_STDOUT
     output = buf.getvalue()
-    # Empty output = allow (pass through to permission system).
-    # Non-empty output must be valid JSON.
+    # Non-empty output must be valid JSON (includes allow decisions).
+    # Empty output = no opinion (fallback — should not happen normally).
     if not output.strip():
-        pass  # allow — write nothing to stdout
+        pass  # no opinion — fall through to agent's own permission system
     else:
         try:
             json.loads(output)

--- a/src/nah/hook.py
+++ b/src/nah/hook.py
@@ -410,12 +410,9 @@ def main():
         else:
             decision = handler(tool_input)
 
-        d = decision.get("decision", taxonomy.ALLOW)
-
-        if d != taxonomy.ALLOW:
-            json.dump(_to_hook_output(decision, agent), sys.stdout)
-            sys.stdout.write("\n")
-            sys.stdout.flush()
+        json.dump(_to_hook_output(decision, agent), sys.stdout)
+        sys.stdout.write("\n")
+        sys.stdout.flush()
 
         total_ms = int((time.monotonic() - t0) * 1000)
         _log_hook_decision(canonical, tool_input, decision, agent, total_ms)

--- a/src/nah/taxonomy.py
+++ b/src/nah/taxonomy.py
@@ -101,7 +101,8 @@ def build_user_table(user_classify: dict[str, list[str]]) -> list[tuple[tuple[st
 _FLAG_CLASSIFIER_CMDS = {"find", "sed", "awk", "gawk", "mawk", "nawk",
                           "tar", "git", "curl", "wget",
                           "http", "https", "xh", "xhs",
-                          "npm", "pnpm", "bun", "pip", "pip3", "cargo", "gem"}
+                          "npm", "pnpm", "bun", "pip", "pip3", "cargo", "gem",
+                          "gh"}
 
 # Global-install flags that escalate to unknown (ask).
 _GLOBAL_INSTALL_FLAGS = {"-g", "--global", "--system", "--target", "--root"}
@@ -298,6 +299,9 @@ def classify_tokens(
         if action is not None:
             return action
         action = _classify_global_install(tokens)
+        if action is not None:
+            return action
+        action = _classify_gh_api(tokens)
         if action is not None:
             return action
 
@@ -594,6 +598,47 @@ def _classify_httpie(tokens: list[str]) -> str | None:
     if has_data_item:
         return NETWORK_WRITE
     return NETWORK_OUTBOUND
+
+
+_GH_API_WRITE_FLAGS = {"--method", "-X"}
+_GH_API_WRITE_METHODS = {"POST", "PUT", "DELETE", "PATCH"}
+_GH_API_DATA_FLAGS = {"--input", "-f", "--raw-field", "-F", "--field"}
+_GH_API_DATA_LONG_PREFIXES = ("--input=", "--raw-field=", "--field=")
+
+
+def _classify_gh_api(tokens: list[str]) -> str | None:
+    """Flag-dependent: gh api with write method/data → network_write; else → git_safe."""
+    if len(tokens) < 2 or tokens[0] != "gh" or tokens[1] != "api":
+        return None
+
+    has_write_method = False
+    has_data = False
+
+    i = 2
+    while i < len(tokens):
+        tok = tokens[i]
+
+        if tok in _GH_API_WRITE_FLAGS:
+            if i + 1 < len(tokens) and tokens[i + 1].upper() in _GH_API_WRITE_METHODS:
+                has_write_method = True
+            i += 2
+            continue
+
+        if tok in _GH_API_DATA_FLAGS:
+            has_data = True
+            i += 2
+            continue
+
+        if any(tok.startswith(p) for p in _GH_API_DATA_LONG_PREFIXES):
+            has_data = True
+            i += 1
+            continue
+
+        i += 1
+
+    if has_data or has_write_method:
+        return NETWORK_WRITE
+    return GIT_SAFE
 
 
 def _classify_global_install(tokens: list[str]) -> str | None:


### PR DESCRIPTION
## Summary

- **Active allow decisions**: Emit `permissionDecision: "allow"` instead of staying silent when a tool call is classified as safe. Claude Code's hook protocol treats empty stdout as "no opinion" (falls through to its own permission system), but `permissionDecision: "allow"` actively bypasses it. This lets nah auto-approve commands it has classified, removing redundant permission prompts for safe operations.

- **`gh api` flag classifier**: Add a Phase 2 flag classifier for `gh api` that distinguishes read-only API calls (GET → `git_safe`) from mutating calls (POST/PUT/DELETE/PATCH or data flags → `network_write`). Previously `gh api` was classified as `lang_exec` regardless of method.

## Motivation

Without active allow, nah can only block/ask — it can't prevent Claude Code from re-prompting for commands nah already deemed safe. This makes the config-driven classify rules (`package_run`, `git_safe`, etc.) ineffective as auto-approve rules. With this change, `pnpm typecheck`, `gt status`, `gh api user`, etc. are truly auto-approved without any permission prompt.

## Test plan

- [ ] `nah test "gh api user"` → `git_safe → ALLOW`
- [ ] `nah test "gh api --method POST /repos/o/r/issues"` → `network_write`
- [ ] `nah test "gh api -X DELETE /repos/o/r/issues/1"` → `network_write`
- [ ] `nah test "gh api -f body=hello /repos/o/r/issues/1/comments"` → `network_write`
- [ ] `nah test "pnpm typecheck"` → `package_run → ALLOW` (with active allow JSON emitted)
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)