### PR TITLE
fix(deps): make pyyaml a required dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,12 @@ classifiers = [
     "Topic :: Software Development :: Quality Assurance",
 ]
 
+dependencies = [
+    "pyyaml>=6.0",
+]
+
 [project.optional-dependencies]
 dev = ["pytest"]
-config = ["pyyaml>=6.0"]
 docs = ["mkdocs-material>=9.0"]
 
 [project.scripts]


### PR DESCRIPTION
Move pyyaml from optional extras (`[project.optional-dependencies] config`) to required `dependencies`.

## Why

Without pyyaml, nah silently ignores the entire config file and falls back to defaults. This means LLM integration, custom classifications, sensitive paths, and action policies are all quietly inactive — with no warning during normal hook usage.

## Reproduce the problem

1. Install nah via `uv tool install nah`
2. Create a config at `~/.config/nah/config.yaml`
3. Run `nah config show` — config is ignored with: `nah: yaml module not available, config ignored`

The user must separately discover and run
`uv tool install nah --with pyyaml` to get config support, which defeats the purpose of a config-driven tool.



I ran into this issue myself and it wasn't obvious why the perms weren't being validated, so used claude to describe the issue. Hope that's fine!