### PR TITLE
Allow per-project configs to loosen policies

### DIFF
--- a/src/nah/config.py
+++ b/src/nah/config.py
@@ -162,18 +162,12 @@ def _validate_dict(val) -> dict:
     return val if isinstance(val, dict) else {}
 
 
-def _merge_dict_tighten(global_d: dict, project_d: dict, defaults: dict | None = None) -> dict:
-    """Merge two dicts — project can only tighten (stricter policy wins)."""
+def _merge_dict_override(global_d: dict, project_d: dict, defaults: dict | None = None) -> dict:
+    """Merge two dicts — project values override global values."""
     merged = dict(global_d)
     for key, val in project_d.items():
-        if key in merged:
-            if _STRICTNESS.get(val, 2) >= _STRICTNESS.get(merged[key], 2):
-                merged[key] = val
-        else:
-            # New key: only accept if at least as strict as the built-in default
-            base = defaults.get(key, "ask") if defaults else "ask"
-            if _STRICTNESS.get(val, 2) >= _STRICTNESS.get(base, 2):
-                merged[key] = val
+        if val in _STRICTNESS:
+            merged[key] = val
     return merged
 
 
@@ -203,23 +197,23 @@ def _merge_configs(global_cfg: dict, project_cfg: dict) -> NahConfig:
     config.classify_global = _validate_dict(global_cfg.get("classify", {}))
     config.classify_project = _validate_dict(project_cfg.get("classify", {}))
 
-    # actions: tighten only (compare new keys against built-in defaults)
-    config.actions = _merge_dict_tighten(
+    # actions: project overrides global
+    config.actions = _merge_dict_override(
         _validate_dict(global_cfg.get("actions", {})),
         _validate_dict(project_cfg.get("actions", {})),
         defaults=_POLICIES,
     )
 
-    # sensitive_paths_default: use project if stricter
+    # sensitive_paths_default: project overrides global
     g_default = global_cfg.get("sensitive_paths_default", "ask")
     p_default = project_cfg.get("sensitive_paths_default", "")
-    if p_default and _STRICTNESS.get(p_default, 2) >= _STRICTNESS.get(g_default, 2):
+    if p_default and p_default in _STRICTNESS:
         config.sensitive_paths_default = p_default
     else:
         config.sensitive_paths_default = g_default if g_default in _STRICTNESS else "ask"
 
-    # sensitive_paths: tighten only
-    config.sensitive_paths = _merge_dict_tighten(
+    # sensitive_paths: project overrides global
+    config.sensitive_paths = _merge_dict_override(
         _validate_dict(global_cfg.get("sensitive_paths", {})),
         _validate_dict(project_cfg.get("sensitive_paths", {})),
     )
@@ -262,7 +256,7 @@ def _merge_configs(global_cfg: dict, project_cfg: dict) -> NahConfig:
     config.content_patterns_suppress = raw_cp_suppress if isinstance(raw_cp_suppress, list) else []
     g_policies = _validate_dict(g_content.get("policies", {}))
     p_policies = _validate_dict(p_content.get("policies", {}))
-    config.content_policies = _merge_dict_tighten(g_policies, p_policies)
+    config.content_policies = _merge_dict_override(g_policies, p_policies)
 
     # credential_patterns: entirely global-only
     g_cred = _validate_dict(global_cfg.get("credential_patterns", {}))

--- a/src/nah/remember.py
+++ b/src/nah/remember.py
@@ -61,23 +61,9 @@ def _get_config_path(project: bool) -> str:
 
 
 def _validate_action_scope(action_type: str, policy: str, project: bool) -> None:
-    """Check that a project config doesn't loosen policy relative to global + defaults."""
-    if not project:
-        return
-    # Read global config to find the effective policy
-    global_path = get_global_config_path()
-    global_data = _read_config(global_path)
-    global_actions = global_data.get("actions", {})
-    if isinstance(global_actions, dict) and action_type in global_actions:
-        effective = global_actions[action_type]
-    else:
-        effective = taxonomy._POLICIES.get(action_type, taxonomy.ASK)
-    # Project policy must be at least as strict
-    if taxonomy.STRICTNESS.get(policy, 2) < taxonomy.STRICTNESS.get(effective, 2):
-        raise ValueError(
-            f"Project config cannot loosen '{action_type}' from {effective} to {policy}. "
-            f"Use global config to allow, or set a stricter policy."
-        )
+    """Validate action scope. Project configs can freely override policies."""
+    # No restriction — project configs can both tighten and loosen policies.
+    pass
 
 
 def write_action(action_type: str, policy: str, project: bool = False,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -96,15 +96,15 @@ class TestMergeConfigs:
         assert cfg.classify_global == {"package_run": ["just build"]}
         assert cfg.classify_project == {"package_run": ["task dev"]}
 
-    def test_actions_tighten_only(self):
-        """Project can tighten actions but not loosen."""
+    def test_actions_project_overrides(self):
+        """Project can both tighten and loosen actions."""
         global_cfg = {"actions": {"filesystem_read": "allow", "network_outbound": "ask"}}
         project_cfg = {"actions": {"filesystem_read": "ask", "network_outbound": "allow"}}
         cfg = _merge_configs(global_cfg, project_cfg)
-        # filesystem_read: allow → ask (tightened) ✓
+        # filesystem_read: allow → ask (tightened)
         assert cfg.actions["filesystem_read"] == "ask"
-        # network_outbound: ask → allow (loosened) — stays at ask
-        assert cfg.actions["network_outbound"] == "ask"
+        # network_outbound: ask → allow (loosened)
+        assert cfg.actions["network_outbound"] == "allow"
 
     def test_actions_project_adds_new(self):
         """Project can add new action types."""
@@ -113,18 +113,18 @@ class TestMergeConfigs:
         cfg = _merge_configs(global_cfg, project_cfg)
         assert cfg.actions["custom_type"] == "block"
 
-    def test_sensitive_paths_tighten_only(self):
-        """Sensitive paths tighten only per path."""
+    def test_sensitive_paths_project_overrides(self):
+        """Project can both tighten and loosen sensitive paths."""
         global_cfg = {"sensitive_paths": {"~/.custom": "ask"}}
         project_cfg = {"sensitive_paths": {"~/.custom": "block"}}
         cfg = _merge_configs(global_cfg, project_cfg)
         assert cfg.sensitive_paths["~/.custom"] == "block"
 
-    def test_sensitive_paths_no_loosen(self):
+    def test_sensitive_paths_project_loosens(self):
         global_cfg = {"sensitive_paths": {"~/.custom": "block"}}
         project_cfg = {"sensitive_paths": {"~/.custom": "ask"}}
         cfg = _merge_configs(global_cfg, project_cfg)
-        assert cfg.sensitive_paths["~/.custom"] == "block"
+        assert cfg.sensitive_paths["~/.custom"] == "ask"
 
     def test_sensitive_paths_union(self):
         global_cfg = {"sensitive_paths": {"~/.a": "ask"}}
@@ -223,12 +223,12 @@ class TestSensitivePathsDefault:
         )
         assert cfg.sensitive_paths_default == "block"
 
-    def test_project_cannot_loosen(self):
+    def test_project_loosens(self):
         cfg = _merge_configs(
             {"sensitive_paths_default": "block"},
             {"sensitive_paths_default": "ask"},
         )
-        assert cfg.sensitive_paths_default == "block"
+        assert cfg.sensitive_paths_default == "ask"
 
 
 class TestProfile:
@@ -503,12 +503,12 @@ class TestContentPatterns:
         )
         assert cfg.content_policies["secret"] == "block"
 
-    def test_content_policies_project_cannot_loosen(self):
+    def test_content_policies_project_loosens(self):
         cfg = _merge_configs(
             {"content_patterns": {"policies": {"secret": "block"}}},
             {"content_patterns": {"policies": {"secret": "ask"}}},
         )
-        assert cfg.content_policies["secret"] == "block"
+        assert cfg.content_policies["secret"] == "ask"
 
     # --- content_patterns invalid types ---
 

--- a/tests/test_fd014_cleanup.py
+++ b/tests/test_fd014_cleanup.py
@@ -12,7 +12,7 @@ from nah.bash import StageResult, _apply_policy, _unwrap_shell, _check_redirect,
 from nah.taxonomy import get_builtin_table
 
 _FULL = get_builtin_table("full")
-from nah.config import _merge_dict_tighten, _validate_dict, _merge_configs
+from nah.config import _merge_dict_override, _validate_dict, _merge_configs
 from nah.context import _extract_positional_host
 from nah.hook import _check_write_content
 
@@ -250,53 +250,35 @@ class TestMergeHelpers:
         assert _validate_dict(None) == {}
         assert _validate_dict(42) == {}
 
-    def test_merge_dict_tighten_keeps_stricter(self):
-        result = _merge_dict_tighten(
+    def test_merge_dict_override_project_wins(self):
+        result = _merge_dict_override(
             {"a": "allow", "b": "ask"},
             {"a": "ask", "b": "allow"},
         )
         assert result["a"] == "ask"  # tightened
-        assert result["b"] == "ask"  # not loosened
+        assert result["b"] == "allow"  # loosened
 
-    def test_merge_dict_tighten_adds_new(self):
-        result = _merge_dict_tighten({"a": "allow"}, {"b": "block"})
+    def test_merge_dict_override_adds_new(self):
+        result = _merge_dict_override({"a": "allow"}, {"b": "block"})
         assert result["a"] == "allow"
         assert result["b"] == "block"
 
-    def test_merge_dict_tighten_new_key_validated_against_defaults(self):
-        """FD-048: new keys compared against built-in defaults, not accepted blindly."""
+    def test_merge_dict_override_accepts_any_valid_policy(self):
+        """Project can set any valid policy value."""
         defaults = {"db_write": "ask", "network_outbound": "context"}
-        # allow < ask → rejected
-        result = _merge_dict_tighten({}, {"db_write": "allow"}, defaults=defaults)
-        assert "db_write" not in result
-        # block > ask → accepted
-        result = _merge_dict_tighten({}, {"db_write": "block"}, defaults=defaults)
+        result = _merge_dict_override({}, {"db_write": "allow"}, defaults=defaults)
+        assert result["db_write"] == "allow"
+        result = _merge_dict_override({}, {"db_write": "block"}, defaults=defaults)
         assert result["db_write"] == "block"
-        # allow < context → rejected
-        result = _merge_dict_tighten({}, {"network_outbound": "allow"}, defaults=defaults)
-        assert "network_outbound" not in result
-        # ask > context → accepted
-        result = _merge_dict_tighten({}, {"network_outbound": "ask"}, defaults=defaults)
-        assert result["network_outbound"] == "ask"
+        result = _merge_dict_override({}, {"network_outbound": "allow"}, defaults=defaults)
+        assert result["network_outbound"] == "allow"
 
-    def test_merge_dict_tighten_unknown_key_defaults_to_ask(self):
-        """FD-048: keys not in defaults dict fall back to 'ask'."""
-        defaults = {"known": "allow"}
-        # unknown key, allow < ask → rejected
-        result = _merge_dict_tighten({}, {"fake_type": "allow"}, defaults=defaults)
-        assert "fake_type" not in result
-        # unknown key, block > ask → accepted
-        result = _merge_dict_tighten({}, {"fake_type": "block"}, defaults=defaults)
-        assert result["fake_type"] == "block"
-
-    def test_merge_dict_tighten_no_defaults_falls_back_to_ask(self):
-        """Without defaults param, new keys still compared against 'ask'."""
-        # allow < ask → rejected
-        result = _merge_dict_tighten({}, {"x": "allow"})
+    def test_merge_dict_override_ignores_invalid_values(self):
+        """Non-policy values are ignored."""
+        result = _merge_dict_override({"a": "ask"}, {"a": "bogus"})
+        assert result["a"] == "ask"
+        result = _merge_dict_override({}, {"x": "nonsense"})
         assert "x" not in result
-        # ask >= ask → accepted
-        result = _merge_dict_tighten({}, {"x": "ask"})
-        assert result["x"] == "ask"
 
     def test_parse_add_remove_list(self):
         from nah.config import _parse_add_remove

--- a/tests/test_remember.py
+++ b/tests/test_remember.py
@@ -59,11 +59,12 @@ class TestWriteAction:
         with pytest.raises(ValueError, match="Did you mean"):
             write_action("git_histori_rewrite", "allow")
 
-    def test_project_loosening_raises(self, patched_paths, global_cfg):
-        from nah.remember import write_action
-        # Default for git_history_rewrite is 'ask'. Trying to set project to 'allow' should fail.
-        with pytest.raises(ValueError, match="cannot loosen"):
-            write_action("git_history_rewrite", "allow", project=True)
+    def test_project_loosening_ok(self, patched_paths, project_cfg):
+        from nah.remember import write_action, _read_config
+        msg = write_action("git_history_rewrite", "allow", project=True)
+        assert "allow" in msg
+        data = _read_config(project_cfg)
+        assert data["actions"]["git_history_rewrite"] == "allow"
 
     def test_project_tightening_ok(self, patched_paths, project_cfg):
         from nah.remember import write_action, _read_config
@@ -181,20 +182,17 @@ class TestForgetRule:
 
 
 class TestValidateActionScope:
-    def test_loosening_detected(self, patched_paths):
+    def test_loosening_allowed(self, patched_paths):
         from nah.remember import _validate_action_scope
-        # Default for git_history_rewrite is 'ask', trying to set 'allow' in project should fail
-        with pytest.raises(ValueError, match="cannot loosen"):
-            _validate_action_scope("git_history_rewrite", "allow", project=True)
+        # Project configs can freely loosen policies
+        _validate_action_scope("git_history_rewrite", "allow", project=True)
 
     def test_tightening_ok(self, patched_paths):
         from nah.remember import _validate_action_scope
-        # Tightening from 'ask' to 'block' should be fine
         _validate_action_scope("git_history_rewrite", "block", project=True)
 
     def test_global_always_ok(self, patched_paths):
         from nah.remember import _validate_action_scope
-        # Global config can do anything
         _validate_action_scope("git_history_rewrite", "allow", project=False)
 
 


### PR DESCRIPTION
Previously, .nah.yaml could only tighten policies relative to the global config (stricter policy always won).

When I know that a project requires a certain set of commands in order for Claude to do its job, I should be able to loosen them for *only that project*. Not allowing this and forcing you to loosen the restriction globally, is more dangerous.

This removes that restriction so project configs can freely override policy values in both directions.

- Rename _merge_dict_tighten → _merge_dict_override (project wins)
- Remove strictness comparison from sensitive_paths_default merge
- Remove _validate_action_scope enforcement in remember.py
- Update tests to expect bidirectional overrides