### PR TITLE
Fix format_error using invalid "block" protocol value

### DIFF
--- a/src/nah/agents.py
+++ b/src/nah/agents.py
@@ -77,7 +77,7 @@ def format_error(error: str, agent: str) -> dict:
     )
     return {"hookSpecificOutput": {
         "hookEventName": "PreToolUse",
-        "permissionDecision": "block",
+        "permissionDecision": "deny",
         "permissionDecisionReason": msg,
     }}
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -94,7 +94,7 @@ class TestFormatError:
     def test_claude_format(self):
         result = agents.format_error("oops", "claude")
         hso = result["hookSpecificOutput"]
-        assert hso["permissionDecision"] == "block"
+        assert hso["permissionDecision"] == "deny"
         assert "oops" in hso["permissionDecisionReason"]
         assert "nah: internal error" in hso["permissionDecisionReason"]
 

--- a/tests/test_fd014_cleanup.py
+++ b/tests/test_fd014_cleanup.py
@@ -341,7 +341,7 @@ class TestErrorDefaultBlock:
         )
         out = json.loads(result.stdout)
         hso = out["hookSpecificOutput"]
-        assert hso["permissionDecision"] == "block"
+        assert hso["permissionDecision"] == "deny"
         assert "error" in hso.get("permissionDecisionReason", "")
 
     def test_malformed_json_returns_block(self):
@@ -352,7 +352,7 @@ class TestErrorDefaultBlock:
         )
         out = json.loads(result.stdout)
         hso = out["hookSpecificOutput"]
-        assert hso["permissionDecision"] == "block"
+        assert hso["permissionDecision"] == "deny"
 
     def test_stderr_has_error_info(self):
         result = subprocess.run(

--- a/tests/test_hook_integration.py
+++ b/tests/test_hook_integration.py
@@ -86,13 +86,13 @@ class TestErrorHandling:
     def test_empty_stdin(self):
         raw, stderr = run_hook_raw("")
         hso = raw["hookSpecificOutput"]
-        assert hso["permissionDecision"] == "block"
+        assert hso["permissionDecision"] == "deny"
         assert "error" in hso.get("permissionDecisionReason", "")
 
     def test_invalid_json(self):
         raw, stderr = run_hook_raw("not json")
         hso = raw["hookSpecificOutput"]
-        assert hso["permissionDecision"] == "block"
+        assert hso["permissionDecision"] == "deny"
         assert "error" in hso.get("permissionDecisionReason", "")
 
     def test_unknown_tool(self):


### PR DESCRIPTION
## Problem

`format_error()` returns `permissionDecision: "block"`, but Claude Code's
hook protocol only accepts `"allow"`, `"deny"`, or `"ask"`.

Commit e7b6afb (FD-065/066) changed `format_error` from `"ask"` to `"block"`
as a fail-closed design. However, `"block"` is nah's internal taxonomy
constant — Claude Code's protocol value for blocking is `"deny"`.

Normal decisions flow through `_to_hook_output()` in `hook.py`, which correctly
maps `taxonomy.BLOCK` to `format_block()` (emitting `"deny"`). But the error
path in `main()` calls `format_error()` directly, bypassing this translation.
Claude Code rejects the unrecognized value and falls through to its built-in
permission system, silently defeating nah's error-path safety guard.

### Note on `"block"` vs `"deny"`

`"block"` is a valid value for the **deprecated** top-level `decision` field,
but not for `hookSpecificOutput.permissionDecision`. The
[Claude Code hooks documentation](https://docs.anthropic.com/en/docs/claude-code/hooks)
states:

> PreToolUse previously used top-level `decision` and `reason` fields, but
> these are deprecated. The deprecated values `"approve"` and `"block"` map
> to `"allow"` and `"deny"` respectively.

Since nah uses the modern `hookSpecificOutput` format, the correct value
is `"deny"`.

## Fix

Change `format_error()` to emit `"deny"` (matching `format_block()`), and
update test assertions that checked for the old value.

## Test plan

- [x] `pytest tests/test_agents.py tests/test_fd014_cleanup.py tests/test_hook_integration.py -v` — all pass (83/83)
- [x] Full test suite — no regressions beyond pre-existing platform-specific failures (Windows path handling)