### PR TITLE
Fix hook command paths breaking in bash on Windows

### DIFF
--- a/src/nah/cli.py
+++ b/src/nah/cli.py
@@ -88,7 +88,10 @@ os._exit(0)
 
 def _hook_command() -> str:
     """Build the command string for settings.json hook entries."""
-    return f"{sys.executable} {_HOOK_SCRIPT}"
+    # Forward slashes: works in both bash and cmd.exe on Windows
+    exe = sys.executable.replace("\\", "/")
+    script = str(_HOOK_SCRIPT).replace("\\", "/")
+    return f"{exe} {script}"
 
 
 def _read_settings(settings_file: Path) -> dict:


### PR DESCRIPTION
## Problem

`_hook_command()` uses `sys.executable` and `pathlib.Path` directly, which
produce backslash paths on Windows (e.g. `C:\Users\test\...\python.exe`).

When Claude Code uses **bash** (Git Bash) as its shell — which is the default
on Windows when Git Bash is installed — backslashes are interpreted as escape
characters:

```
C:\Users\test\AppData\Local\Python\...
```

becomes:

```
C:UserstestAppDataLocalPython...
```

The hook process is never started. Claude Code reports `PreToolUse hook error`
at startup, then silently stops invoking hooks for the rest of the session.

## Fix

Replace backslashes with forward slashes in `_hook_command()`. Forward slashes
work as path separators in **both** bash and cmd.exe on Windows.

Before:
```json
"command": "C:\Users\test\...\python.exe C:\Users\test\...\nah_guard.py"
```

After:
```json
"command": "C:/Users/test/.../python.exe C:/Users/test/.../nah_guard.py"
```

Users need to run `nah install` (or `nah update`) after upgrading to regenerate
the hook entries in settings.json.

## Test plan

- [x] `nah install` produces forward-slash paths in settings.json
- [x] Hook invoked successfully by Claude Code after restart (verified via `nah log`)
- [x] Full test suite — no new regressions (15 pre-existing Windows path failures)
- [x] Manual: `echo '{"tool_name":"Bash",...}' | python nah_guard.py` works with both path styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)