### PR TITLE
Handle joined and short global-install flags

### DIFF
--- a/src/nah/taxonomy.py
+++ b/src/nah/taxonomy.py
@@ -613,6 +613,10 @@ def _classify_global_install(tokens: list[str]) -> str | None:
     for tok in tokens[1:]:
         if tok in _GLOBAL_INSTALL_FLAGS:
             return UNKNOWN
+        if tok.startswith(("--global=", "--system=", "--target=", "--root=")):
+            return UNKNOWN
+        if tokens[0] in {"pip", "pip3"} and tok == "-t":
+            return UNKNOWN
     return None
 
 

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -125,6 +125,15 @@ class TestClassifyTokens:
     def test_package_install(self, tokens):
         assert _ct(tokens) == "package_install"
 
+    @pytest.mark.parametrize("tokens", [
+        ["pip", "install", "--target=/tmp/lib", "flask"],
+        ["pip", "install", "--root=/opt", "flask"],
+        ["pip", "install", "-t", "/tmp/lib", "flask"],
+        ["pip3", "install", "-t", "/tmp/lib", "flask"],
+    ])
+    def test_global_install_flag_variants_escalate_to_unknown(self, tokens):
+        assert _ct(tokens) == "unknown"
+
     # package_run
     @pytest.mark.parametrize("tokens", [
         ["npx", "create-react-app"],


### PR DESCRIPTION
## Summary

- Detect `--global=`, `--system=`, `--target=`, `--root=` (value joined with `=`) as global-install flags
- Add pip/pip3 short `-t` flag detection
- Previously only space-separated forms (`--target /path`) were caught; `--target=/path` slipped through as a normal `package_install → allow`

## Source

Cherry-picked from `autoresearch/hackathon` (commit `e115e7f`), cluster C11 per integration plan in bead `nah-g6g`.

## Test plan

- [x] 4 new parametrized tests pass (`--target=`, `--root=`, `-t` for pip/pip3)
- [x] Full suite: 2092 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)