### PR TITLE
Classify find -exec payload, respect stricter project overrides

### DIFF
--- a/src/nah/bash.py
+++ b/src/nah/bash.py
@@ -61,10 +61,12 @@ def classify_command(command: str) -> ClassifyResult:
     project_table = None
     user_actions = None
     profile = "full"
+    trust_project = False
     try:
         from nah.config import get_config  # lazy import
         cfg = get_config()
         profile = cfg.profile
+        trust_project = cfg.trust_project_config
         if cfg.classify_global:
             global_table = taxonomy.build_user_table(cfg.classify_global)
         builtin_table = taxonomy.get_builtin_table(cfg.profile)
@@ -99,7 +101,7 @@ def classify_command(command: str) -> ClassifyResult:
     for stage in stages:
         sr = _classify_stage(stage, global_table=global_table, builtin_table=builtin_table,
                              project_table=project_table, user_actions=user_actions,
-                             profile=profile)
+                             profile=profile, trust_project=trust_project)
         result.stages.append(sr)
 
     # Check pipe composition rules
@@ -295,6 +297,7 @@ def _classify_stage(
     project_table: list | None = None,
     user_actions: dict[str, str] | None = None,
     profile: str = "full",
+    trust_project: bool = False,
 ) -> StageResult:
     """Classify a single pipeline stage."""
     tokens = stage.tokens
@@ -315,13 +318,14 @@ def _classify_stage(
     # Shell unwrapping
     unwrapped = _unwrap_shell(stage, depth, global_table=global_table,
                               builtin_table=builtin_table, project_table=project_table,
-                              user_actions=user_actions, profile=profile)
+                              user_actions=user_actions, profile=profile,
+                              trust_project=trust_project)
     if unwrapped is not None:
         return unwrapped
 
     # Classify tokens
     sr.action_type = taxonomy.classify_tokens(tokens, global_table, builtin_table, project_table,
-                                              profile=profile)
+                                              profile=profile, trust_project=trust_project)
     sr.default_policy = taxonomy.get_policy(sr.action_type, user_actions)
 
     # Handle redirect target — treat as filesystem_write for the target path
@@ -457,6 +461,7 @@ def _unwrap_shell(
     project_table: list | None,
     user_actions: dict[str, str] | None,
     profile: str = "full",
+    trust_project: bool = False,
 ) -> StageResult | None:
     """Try shell unwrapping. Returns StageResult if handled, None if not a wrapper."""
     tokens = stage.tokens
@@ -471,7 +476,8 @@ def _unwrap_shell(
             inner_stage = Stage(tokens=inner, operator=stage.operator)
             return _classify_stage(inner_stage, depth + 1, global_table=global_table,
                                    builtin_table=builtin_table, project_table=project_table,
-                                   user_actions=user_actions, profile=profile)
+                                   user_actions=user_actions, profile=profile,
+                                   trust_project=trust_project)
         return None  # Introspection or bare — fall through to classify
 
     # xargs unwrap (FD-089)
@@ -490,7 +496,8 @@ def _unwrap_shell(
         inner_stage = Stage(tokens=inner_tokens, operator=stage.operator)
         return _classify_stage(inner_stage, depth + 1, global_table=global_table,
                                builtin_table=builtin_table, project_table=project_table,
-                               user_actions=user_actions, profile=profile)
+                               user_actions=user_actions, profile=profile,
+                               trust_project=trust_project)
 
     is_wrapper, inner = taxonomy.is_shell_wrapper(tokens)
     if not is_wrapper or inner is None:
@@ -523,7 +530,7 @@ def _unwrap_shell(
         return _classify_inner(inner_stages, stage, depth + 1,
                                global_table=global_table, builtin_table=builtin_table,
                                project_table=project_table, user_actions=user_actions,
-                               profile=profile)
+                               profile=profile, trust_project=trust_project)
 
     return None
 
@@ -538,10 +545,12 @@ def _classify_inner(
     project_table: list | None,
     user_actions: dict[str, str] | None,
     profile: str = "full",
+    trust_project: bool = False,
 ) -> StageResult:
     """Classify pre-decomposed inner stages."""
     kw = dict(global_table=global_table, builtin_table=builtin_table,
-              project_table=project_table, user_actions=user_actions, profile=profile)
+              project_table=project_table, user_actions=user_actions, profile=profile,
+              trust_project=trust_project)
 
     if len(inner_stages) <= 1:
         # Simple case — single command, no operators

--- a/src/nah/hook.py
+++ b/src/nah/hook.py
@@ -374,7 +374,8 @@ def _classify_unknown_tool(canonical: str, tool_input: dict | None = None) -> di
         return {"decision": taxonomy.ASK, "reason": f"unrecognized tool: {canonical}"}
 
     action_type = taxonomy.classify_tokens([canonical], global_table, builtin_table, project_table,
-                                           profile=cfg.profile)
+                                           profile=cfg.profile,
+                                           trust_project=cfg.trust_project_config)
 
     policy = taxonomy.get_policy(action_type, user_actions)
     if policy == taxonomy.ALLOW:

--- a/src/nah/taxonomy.py
+++ b/src/nah/taxonomy.py
@@ -249,12 +249,16 @@ def classify_tokens(
     project_table: list | None = None,
     *,
     profile: str = "full",
+    trust_project: bool = False,
 ) -> str:
     """Classify command tokens via three-phase lookup.
 
     Phase 1: Global table (trusted user config) — always runs.
     Phase 2: Flag classifiers (built-in opinions) — skipped when profile == "none".
     Phase 3: Remaining tables (project, builtin) — global already checked.
+        When trust_project is True, project table wins over builtins even
+        when it loosens policy (user explicitly opted in via
+        trust_project_config in global config).
     """
     if not tokens:
         return UNKNOWN
@@ -288,6 +292,7 @@ def classify_tokens(
             builtin_table=builtin_table,
             project_table=project_table,
             profile=profile,
+            trust_project=trust_project,
         )
         if action is not None:
             return action
@@ -318,8 +323,8 @@ def classify_tokens(
             return action
 
     # --- Phase 3: Remaining tables (project, builtin) ---
-    # Project table may override built-ins only when it does not weaken policy.
-    # This preserves supply-chain safety while allowing project-specific tightening.
+    # Project table may override built-ins only when it does not weaken policy,
+    # unless trust_project is True (user opted in via trust_project_config).
     project_result = _prefix_match(tokens, project_table) if project_table else UNKNOWN
     builtin_result = _prefix_match(tokens, builtin_table) if builtin_table else UNKNOWN
 
@@ -328,6 +333,10 @@ def classify_tokens(
     if builtin_result == UNKNOWN:
         return project_result
     if project_result == builtin_result:
+        return project_result
+
+    # Trusted project: project wins unconditionally (user explicitly opted in).
+    if trust_project:
         return project_result
 
     project_policy = get_policy(project_result)
@@ -372,6 +381,7 @@ def _classify_find(
     builtin_table: list | None = None,
     project_table: list | None = None,
     profile: str = "full",
+    trust_project: bool = False,
 ) -> str | None:
     """Special classifier for find — inspect -exec payloads conservatively."""
     if not tokens or tokens[0] != "find":
@@ -389,6 +399,7 @@ def _classify_find(
                 builtin_table=builtin_table,
                 project_table=project_table,
                 profile=profile,
+                trust_project=trust_project,
             )
             return inner_action if inner_action != UNKNOWN else FILESYSTEM_DELETE
     return FILESYSTEM_READ

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -419,6 +419,31 @@ class TestClassifyTokens:
             profile="full",
         ) == "container_destructive"
 
+    def test_project_cannot_loosen_builtin_without_trust(self):
+        """Without trust_project, project classify cannot weaken a builtin."""
+        # docker rm is container_destructive (ask) in builtins;
+        # project tries to reclassify as filesystem_read (allow) — should be denied.
+        tbl = build_user_table({"filesystem_read": ["docker rm"]})
+        builtin = get_builtin_table("full")
+        assert classify_tokens(
+            ["docker", "rm", "abc"],
+            builtin_table=builtin,
+            project_table=tbl,
+            profile="none",
+        ) == "container_destructive"
+
+    def test_project_can_loosen_builtin_with_trust(self):
+        """With trust_project=True, project classify can weaken a builtin."""
+        tbl = build_user_table({"filesystem_read": ["docker rm"]})
+        builtin = get_builtin_table("full")
+        assert classify_tokens(
+            ["docker", "rm", "abc"],
+            builtin_table=builtin,
+            project_table=tbl,
+            profile="none",
+            trust_project=True,
+        ) == "filesystem_read"
+
     def test_user_classify_multi_token_path(self):
         """Path in non-first position: only first token gets basename'd."""
         tbl = build_user_table({"testing": ["php vendor/bin/codecept run"]})


### PR DESCRIPTION
## Summary

**find -exec payload classification:**
- `find -exec` now extracts the payload command and recursively classifies it
- `find . -exec grep -l needle {} +` → `filesystem_read` (was falsely `filesystem_delete`)
- `find . -exec rm {} ;` → `filesystem_delete` (still correct)
- Falls back to `filesystem_delete` if payload is empty or unknown (fail-closed)

**Stricter project overrides:**
- Phase 3 of `classify_tokens` now evaluates project and builtin tables independently and picks the stricter result
- Project configs can tighten (e.g. `make docker-clean → container_destructive`) but cannot weaken built-in protections
- Uses `STRICTNESS` ordering for policy comparison

**trust_project_config compatibility:**
- Added `trust_project` param threaded through `classify_tokens` → `_classify_find` → `_classify_stage` → `_unwrap_shell` → `_classify_inner`
- When `trust_project_config: true` in global config, project classify table can loosen builtins (user explicitly opted in)
- Without it, only tightening is allowed (stricter-wins default)

## Source

Cherry-picked from `autoresearch/hackathon` (commits `bee1396`, `e687086`), cluster C10 per bead `nah-g6g`. Third commit is a fix for compatibility with `trust_project_config`.

## Test plan

- [x] `test_find_exec` — `find -exec grep` → `filesystem_read`
- [x] `test_find_exec_delete_command` — `find -exec rm` → `filesystem_delete`
- [x] `test_project_table_overrides_builtin_prefix` — project tightening works
- [x] `test_project_cannot_loosen_builtin_without_trust` — loosening blocked by default
- [x] `test_project_can_loosen_builtin_with_trust` — loosening allowed with trust_project=True
- [x] Full suite: 2093 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)