### PR TITLE
Preserve redirect checks after shell unwrapping

### DIFF
--- a/src/nah/bash.py
+++ b/src/nah/bash.py
@@ -375,7 +375,7 @@ def _classify_stage(
         sr.default_policy = taxonomy.get_policy(sr.action_type, user_actions)
         _apply_policy(sr)
         sr.reason = stage.action_reason or f"env var exec sink: {sr.action_type} → {sr.decision}"
-        return sr
+        return _apply_redirect_guard(stage, sr)
 
     # Shell unwrapping
     unwrapped = _unwrap_shell(stage, depth, global_table=global_table,
@@ -383,20 +383,12 @@ def _classify_stage(
                               user_actions=user_actions, profile=profile,
                               trust_project=trust_project)
     if unwrapped is not None:
-        return unwrapped
+        return _apply_redirect_guard(stage, unwrapped)
 
     # Classify tokens
     sr.action_type = taxonomy.classify_tokens(tokens, global_table, builtin_table, project_table,
                                               profile=profile, trust_project=trust_project)
     sr.default_policy = taxonomy.get_policy(sr.action_type, user_actions)
-
-    # Handle redirect target — treat as filesystem_write for the target path
-    if stage.redirect_target:
-        redir_decision, redir_reason = _check_redirect(stage.redirect_target)
-        if redir_decision in (taxonomy.BLOCK, taxonomy.ASK):
-            sr.decision = redir_decision
-            sr.reason = f"redirect target: {redir_reason}"
-            return sr
 
     # Apply policy → decision
     _apply_policy(sr)
@@ -407,7 +399,7 @@ def _classify_stage(
         sr.decision = path_decision
         sr.reason = path_reason
 
-    return sr
+    return _apply_redirect_guard(stage, sr)
 
 
 def _obfuscated_result(tokens: list[str], reason: str, user_actions: dict[str, str] | None) -> StageResult:
@@ -658,6 +650,18 @@ def _apply_policy(sr: StageResult) -> None:
     else:
         sr.decision = taxonomy.ASK
         sr.reason = f"unknown policy: {sr.default_policy}"
+
+
+def _apply_redirect_guard(stage: Stage, sr: StageResult) -> StageResult:
+    """Escalate a stage result when the outer stage redirects output to disk."""
+    if not stage.redirect_target:
+        return sr
+
+    redir_decision, redir_reason = _check_redirect(stage.redirect_target)
+    if taxonomy.STRICTNESS.get(redir_decision, 0) > taxonomy.STRICTNESS.get(sr.decision, 0):
+        sr.decision = redir_decision
+        sr.reason = f"redirect target: {redir_reason}"
+    return sr
 
 
 def _check_redirect(target: str) -> tuple[str, str]:

--- a/tests/test_bash.py
+++ b/tests/test_bash.py
@@ -262,6 +262,11 @@ class TestUnwrapping:
         r = classify_command("bash -c 'git status'")
         assert r.final_decision == "allow"
 
+    def test_bash_c_redirect_preserved_after_unwrap(self, project_root):
+        r = classify_command("bash -c 'grep ERROR' > /etc/passwd")
+        assert r.final_decision == "ask"
+        assert "redirect target" in r.reason
+
 
 # --- FD-049: command builtin unwrap ---
 
@@ -321,6 +326,11 @@ class TestCommandUnwrap:
         assert r.stages[0].action_type == "git_safe"
         assert r.final_decision == "allow"
 
+    def test_redirect_preserved_after_unwrap(self, project_root):
+        r = classify_command("command grep ERROR > /etc/passwd")
+        assert r.final_decision == "ask"
+        assert "redirect target" in r.reason
+
     def test_process_signal(self, project_root):
         r = classify_command("command kill -9 1234")
         assert r.stages[0].action_type == "process_signal"
@@ -341,6 +351,11 @@ class TestXargsUnwrap:
         r = classify_command("find . | xargs wc -l")
         assert r.stages[1].action_type == "filesystem_read"
         assert r.final_decision == "allow"
+
+    def test_xargs_redirect_preserved_after_unwrap(self, project_root):
+        r = classify_command("find . | xargs grep ERROR > /etc/passwd")
+        assert r.final_decision == "ask"
+        assert "redirect target" in r.reason
 
     def test_xargs_rm(self, project_root):
         r = classify_command("find . | xargs rm")


### PR DESCRIPTION
## Summary

- Extract `_apply_redirect_guard()` and call it on all 3 return paths in `_classify_stage()`
- Previously, redirect checks were skipped after shell unwrapping (bash -c, command, xargs)
- `bash -c 'grep ERROR' > /etc/passwd` now correctly ASKs instead of allowing
- Uses strictness comparison — only escalates if redirect is stricter than inner classification

Closes bead **nah-pd8** (Redirect Propagation Fix in Unwrapping).

## Source

Cherry-picked from `autoresearch/hackathon` (commit `ef5a0fa`), cluster C3 per bead `nah-g6g`.
Depends on PR #30 (C1).

## Test plan

- [x] `bash -c 'grep ERROR' > /etc/passwd` -> ask (redirect preserved after unwrap)
- [x] `command grep ERROR > /etc/passwd` -> ask (redirect preserved)
- [x] Full suite: 2140 passed, 0 failed
