### PR TITLE
Docs: add active_allow examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,19 @@ Once installed, nah handles permissions for everything Claude Code does in your 
 
 **Don't use `--dangerously-skip-permissions`** — just run `claude` in default mode. In `--dangerously-skip-permissions` mode, hooks [fire asynchronously](https://github.com/anthropics/claude-code/issues/20946) and commands execute before nah can block them.
 
-To control which tools nah actively allows, set `active_allow` in `~/.config/nah/config.yaml`. See [configuration docs](https://schipper.ai/nah/configuration/).
+By default nah actively allows safe operations for all guarded tools. To keep nah's protection on some tools but let others fall back to Claude Code's built-in prompts, set `active_allow` to a list:
+
+```yaml
+# ~/.config/nah/config.yaml
+
+# Only actively allow these tools (Write/Edit fall back to Claude Code's prompts)
+active_allow: [Bash, Read, Glob, Grep]
+
+# Or disable active allow entirely
+active_allow: false
+```
+
+Valid tool names: `Bash`, `Read`, `Write`, `Edit`, `Glob`, `Grep`. See [configuration docs](https://schipper.ai/nah/configuration/).
 
 To uninstall: `nah uninstall && pip uninstall nah`.
 

--- a/site/index.md
+++ b/site/index.md
@@ -64,6 +64,17 @@ Claude: Bash → base64 -d payload | bash
 | **Grep** | Catches credential search patterns outside the project |
 | **MCP** | Generic classification for third-party tool servers |
 
+## Choose what nah handles
+
+By default nah actively allows safe operations for all tools. Want Claude Code's normal prompts for writes and edits, but nah's protection for everything else?
+
+```yaml
+# ~/.config/nah/config.yaml
+active_allow: [Bash, Read, Glob, Grep]
+```
+
+nah still blocks and asks for dangerous operations on all tools — this only controls which safe operations get automatic allow. See [active_allow](install.md#active_allow) for details.
+
 ---
 
 [Install](install.md) | [Configure](configuration/index.md) | [How it works](how-it-works.md) | [Getting started](guides/getting-started.md)

--- a/site/install.md
+++ b/site/install.md
@@ -31,18 +31,26 @@ WebFetch and WebSearch are not guarded by nah. Claude Code handles those with it
 
 ### active_allow
 
-By default nah actively allows safe operations for all guarded tools. You can control this per tool:
+When nah classifies a tool call as safe, it emits an explicit `"allow"` response so Claude Code skips its own permission prompt. This is **active allow** — nah takes over the permission decision entirely.
+
+Sometimes you want nah's protection (blocking dangerous commands, flagging sensitive paths) but still want Claude Code to prompt you before writes or edits. Set `active_allow` to a list of tool names to control which tools nah actively allows:
 
 ```yaml
 # ~/.config/nah/config.yaml
 
-# Only actively allow these tools (Write/Edit fall back to Claude Code's prompts)
+# nah handles Bash/Read/Glob/Grep; Write/Edit fall back to Claude Code's prompts
 active_allow: [Bash, Read, Glob, Grep]
-
-# Disable active allow entirely (nah still blocks/asks, but safe operations
-# fall through to Claude Code's permission system)
-active_allow: false
 ```
+
+nah still classifies **all** tool calls regardless of this setting — it will still block or ask for dangerous operations on Write/Edit. The only difference is that *safe* Write/Edit calls won't get an automatic allow from nah, so Claude Code shows its normal permission prompt.
+
+| Value | Behavior |
+|-------|----------|
+| `true` (default) | Actively allow all guarded tools |
+| `false` | Never actively allow — nah only blocks and asks |
+| list of tool names | Actively allow only the listed tools |
+
+Valid tool names: `Bash`, `Read`, `Write`, `Edit`, `Glob`, `Grep`.
 
 ## Update
 


### PR DESCRIPTION
Docs: add active_allow examples to README and site

The active_allow config option was underdocumented — README had a
one-liner with no example, and the site install page showed YAML
without explaining what active_allow does or why you'd use it.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
