### PR TITLE
db_write default policy: ask → context (nah-10a)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,11 +142,12 @@ sensitive_paths:
   ~/.kube: ask
   ~/Documents/taxes: block
 
-# Teach nah about your commands
+# Teach nah about your custom commands
 classify:
-  database_destructive:
-    - "psql -c DROP"
-    - "mysql -e DROP"
+  filesystem_delete:
+    - cleanup-staging
+  db_write:
+    - migrate-prod
 ```
 
 nah classifies commands by **action type**, not by command name. Run `nah types` to see all 23 built-in action types with their default policies.

--- a/src/nah/data/policies.json
+++ b/src/nah/data/policies.json
@@ -16,7 +16,7 @@
   "process_signal": "ask",
   "container_destructive": "ask",
   "db_read": "allow",
-  "db_write": "ask",
+  "db_write": "context",
   "beads_safe": "allow",
   "beads_write": "allow",
   "beads_destructive": "ask",

--- a/tests/test_bash.py
+++ b/tests/test_bash.py
@@ -1038,18 +1038,8 @@ class TestFD018Regressions:
 class TestContextResolverFallback:
     """FD-046: Non-filesystem/network types with context policy must ASK."""
 
-    def test_db_write_context_policy_asks(self, project_root, monkeypatch):
-        """db_write dispatched to _resolve_context() with no targets gets ASK."""
-        from nah import taxonomy
-
-        original = taxonomy.get_policy
-
-        def patched(action_type, user_overrides):
-            if action_type == "db_write":
-                return "context"
-            return original(action_type, user_overrides)
-
-        monkeypatch.setattr(taxonomy, "get_policy", patched)
+    def test_db_write_context_policy_asks(self, project_root):
+        """db_write with default context policy and no targets gets ASK."""
         r = classify_command("psql -c 'SELECT 1'")
         assert r.final_decision == "ask"
 

--- a/tests/test_fd014_cleanup.py
+++ b/tests/test_fd014_cleanup.py
@@ -265,7 +265,7 @@ class TestMergeHelpers:
 
     def test_merge_dict_tighten_new_key_validated_against_defaults(self):
         """FD-048: new keys compared against built-in defaults, not accepted blindly."""
-        defaults = {"db_write": "ask", "network_outbound": "context"}
+        defaults = {"db_write": "context", "network_outbound": "context"}
         # allow < ask → rejected
         result = _merge_dict_tighten({}, {"db_write": "allow"}, defaults=defaults)
         assert "db_write" not in result

--- a/tests/test_hook_classify.py
+++ b/tests/test_hook_classify.py
@@ -202,8 +202,8 @@ class TestClassifyUnknownToolContext:
         assert d["decision"] == "ask"
         assert "unknown host" in d["reason"]
 
-    def test_mcp_db_write_default_policy_ask(self):
-        """db_write with default policy (ask, not context) → no context resolution."""
+    def test_mcp_db_write_default_policy_context_with_targets(self):
+        """db_write with default policy (context) + matching db_targets → allow."""
         config._cached_config = NahConfig(
             classify_global={"db_write": ["mcp__snowflake__execute_sql"]},
             db_targets=[{"database": "SANDBOX"}],
@@ -212,8 +212,8 @@ class TestClassifyUnknownToolContext:
             "mcp__snowflake__execute_sql",
             {"database": "SANDBOX", "query": "INSERT INTO t VALUES (1)"},
         )
-        assert d["decision"] == "ask"
-        assert "allowed target" not in d.get("reason", "")
+        assert d["decision"] == "allow"
+        assert "allowed target" in d.get("reason", "")
 
 
 # --- FD-054: Write/Edit project boundary tests ---

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -553,7 +553,7 @@ class TestGetPolicy:
         ("process_signal", "ask"),
         ("container_destructive", "ask"),
         ("db_read", "allow"),
-        ("db_write", "ask"),
+        ("db_write", "context"),
         ("beads_safe", "allow"),
         ("beads_write", "allow"),
         ("beads_destructive", "ask"),


### PR DESCRIPTION
## Summary

- db_write default policy changed from ask to context — enables db_targets config to actually take effect without requiring users to also set actions: {db_write: context}
- Unconfigured users see no behavior change (resolve_database_context returns ask when no db_targets are set)
- Consistent with filesystem_write, filesystem_delete, network_outbound, network_write which all default to context
- Fixed stale README classify example (database_destructive → realistic custom commands)

## Test plan

- [x] nah types shows db_write as context
- [x] nah test "psql -d mydb" with no db_targets → still asks
- [x] nah test "snowsql -q 'DROP TABLE'" → still asks (unknown target)
- [x] MCP db_write with matching db_targets → allows
- [x] All 2532 tests pass
