### PR TITLE
nah: stabilize FD-025 config verification test

### DIFF
--- a/tests/test_fd025_verify.py
+++ b/tests/test_fd025_verify.py
@@ -1,4 +1,4 @@
-"""FD-025 live verification: config overrides are wired end-to-end."""
+"""FD-025 verification: config overrides are wired end-to-end."""
 
 import os
 from unittest.mock import patch
@@ -21,10 +21,13 @@ def _check(tool, path):
 
 
 class TestFD025LiveVerification:
-    """Verify config overrides with the real ~/.config/nah/config.yaml."""
+    """Verify config overrides through the real config loading path."""
 
-    def test_keys_file_ask_from_config(self):
-        assert _check("Read", HOME + "/.keys") == "ask"
+    def test_keys_file_ask_from_config(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("sensitive_paths:\n  ~/.keys: ask\n")
+        with patch("nah.config._GLOBAL_CONFIG", str(cfg)):
+            assert _check("Read", HOME + "/.keys") == "ask"
 
     def test_gnupg_hardcoded_block(self):
         assert _check("Read", HOME + "/.gnupg/key") == "block"


### PR DESCRIPTION
## Category
tests

## Priority
Med

## Problem
FD-025 verification relied on the developer's ambient ~/.config/nah/config.yaml containing a ~/.keys override, so the suite failed in clean sandboxes.

## Solution
Create a temporary global config inside the test, patch nah.config._GLOBAL_CONFIG to it, and keep the same end-to-end config loading path under test.

## Test Results
2628 passed, 10 skipped, 16 xfailed

## Bead
`nah-ci8`