### PR TITLE
Fix _hook_command() paths for Windows bash shells

### DIFF
--- a/src/nah/cli.py
+++ b/src/nah/cli.py
@@ -88,7 +88,14 @@ os._exit(0)
 
 def _hook_command() -> str:
     """Build the command string for settings.json hook entries."""
-    return f"{shlex.quote(sys.executable)} {shlex.quote(str(_HOOK_SCRIPT))}"
+    # Use POSIX forward-slash paths: safe in both bash and cmd.exe on Windows.
+    # shlex.quote() produces POSIX single-quoting which only works when the
+    # command is interpreted by a POSIX shell. Claude Code may invoke hooks
+    # via cmd.exe or direct OS spawn, where single quotes are literal chars.
+    # as_posix() eliminates backslashes at the source, sidestepping the issue.
+    exe = Path(sys.executable).as_posix()
+    script = _HOOK_SCRIPT.as_posix()
+    return f'"{exe}" "{script}"'
 
 
 def _build_hooks_settings() -> dict:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -575,3 +575,47 @@ class TestCmdClaude:
         args = exec_calls[0][1]
         assert "--resume" in args
         assert "--verbose" in args
+
+
+class TestHookCommand:
+    """_hook_command() must produce quoted POSIX paths for bash compatibility."""
+
+    def test_windows_backslashes_converted(self, monkeypatch):
+        """Backslash paths from sys.executable/pathlib are converted to forward slashes."""
+        import shlex
+        import nah.cli as cli_mod
+        from pathlib import PureWindowsPath
+        monkeypatch.setattr(cli_mod, "_HOOK_SCRIPT",
+                            PureWindowsPath(r"C:\Users\test\.claude\hooks\nah_guard.py"))
+        monkeypatch.setattr("sys.executable",
+                            r"C:\Users\test\AppData\Local\Python\python.exe")
+        cmd = cli_mod._hook_command()
+        assert "\\" not in cmd
+        assert "C:/Users/test" in cmd
+        assert len(shlex.split(cmd)) == 2
+
+    def test_shlex_parses_to_two_tokens(self, monkeypatch):
+        """Output is a valid shell command with exactly two tokens."""
+        import shlex
+        import nah.cli as cli_mod
+        from pathlib import PurePosixPath
+        monkeypatch.setattr(cli_mod, "_HOOK_SCRIPT",
+                            PurePosixPath("/home/user/.claude/hooks/nah_guard.py"))
+        monkeypatch.setattr("sys.executable", "/usr/bin/python3")
+        parts = shlex.split(cli_mod._hook_command())
+        assert len(parts) == 2
+        assert "python" in parts[0]
+        assert parts[1].endswith("nah_guard.py")
+
+    def test_spaces_in_paths_preserved(self, monkeypatch):
+        """Paths with spaces are quoted so bash treats each as one token."""
+        import shlex
+        import nah.cli as cli_mod
+        from pathlib import PurePosixPath
+        monkeypatch.setattr(cli_mod, "_HOOK_SCRIPT",
+                            PurePosixPath("/home/my user/.claude/hooks/nah_guard.py"))
+        monkeypatch.setattr("sys.executable", "/opt/my python/bin/python3")
+        parts = shlex.split(cli_mod._hook_command())
+        assert len(parts) == 2
+        assert "my python" in parts[0]
+        assert "my user" in parts[1]


### PR DESCRIPTION
## Summary

- Replace `shlex.quote()` with `Path.as_posix()` + double quotes in `_hook_command()` to produce forward-slash paths that work reliably across all Windows shell environments

## Motivation

On Windows, `sys.executable` and `pathlib.Path` produce backslash paths (e.g. `C:\Users\test\...\python.exe`). When Claude Code uses **bash** (Git Bash / MSYS2) as its shell — which is the default when Git Bash is installed — backslashes are interpreted as escape characters, so `C:\Users\test` becomes `C:Userstest` and the hook process fails silently.

The current `shlex.quote()` approach wraps paths in POSIX single quotes, which preserves backslashes when interpreted by a POSIX-compatible shell. However, Claude Code may invoke hook commands through cmd.exe or directly via OS process spawn, where single quotes have no special meaning — leaving backslashes unprotected as escape characters if the command later passes through any bash-like layer.

`Path.as_posix()` eliminates backslashes entirely by converting to forward slashes, which are valid path separators on Windows in both bash and cmd.exe. Double quotes handle paths with spaces (e.g. `C:/Program Files/...`).

Before:
```json
"command": "'C:\Users\test\...\python.exe' 'C:\Users\test\...\nah_guard.py'"
```

After:
```json
"command": "\"C:/Users/test/.../python.exe\" \"C:/Users/test/.../nah_guard.py\""
```

## Changes

- **`src/nah/cli.py`**: Replace `shlex.quote()` with `Path.as_posix()` + double-quote wrapping in `_hook_command()`
- **`tests/test_cli.py`**: Add `TestHookCommand` class with 3 tests — backslash conversion, shlex parsing, and space-in-path handling

## Testing

- [x] `TestHookCommand` — 3/3 passed
- [x] Full `test_cli.py` suite — 47/47 passed (no regressions)
- [x] `nah install` produces forward-slash paths in settings.json
- [x] Hook invoked successfully by Claude Code on Windows (verified via `nah log`)
- [x] Verified `json.dump` preserves `shlex.quote` single quotes — the issue is not JSON serialization but shell interpretation ambiguity on Windows