### PR TITLE
nah: restore log entry user fallback

### DIFF
--- a/src/nah/log.py
+++ b/src/nah/log.py
@@ -74,11 +74,20 @@ def build_entry(
     meta: dict, transcript_path: str = "",
 ) -> dict:
     """Build a structured log entry with core + detail fields."""
+    import getpass
+
     from nah.paths import get_project_root  # lazy import to avoid circular
+
+    user = os.environ.get("USER") or os.environ.get("LOGNAME")
+    if not user:
+        try:
+            user = getpass.getuser()
+        except Exception:
+            user = ""
 
     entry: dict = {
         "id": os.urandom(8).hex(),
-        "user": os.environ.get("USER", ""),
+        "user": user,
         "agent": agent,
         "hook_version": hook_version,
         "tool": tool,


### PR DESCRIPTION
## Summary

- Restore resilient structured-log user attribution by falling back from `USER` to `LOGNAME` and finally `getpass.getuser()` when the environment is sparse (`src/nah/log.py`)
- `tests/test_log.py::TestBuildEntry::test_core_fields_present` now passes in sandboxes where `USER` is unset instead of emitting `user: ""`
- Preserve the existing log schema and behavior everywhere else while making baseline verification green again

---
Category: tests | Priority: Med | Bead: `nah-xcz`

## Test plan

- [x] `pytest tests/test_log.py::TestBuildEntry::test_core_fields_present -q -vv` — 1 passed
- [x] `pytest tests/ -q --tb=no` — 2965 passed, 13 skipped, 16 xfailed
- [x] `env -u USER LOGNAME=logname-fallback python3 - <<'PY' ...` — structured log entry resolves `user` to `logname-fallback`
- [x] `env -u USER -u LOGNAME python3 - <<'PY' ...` — structured log entry resolves `user` via `getpass.getuser()` (`pn` here)

🤖 Generated by [autoharden](https://github.com/manuelschipper/nah)
