### PR TITLE
nah: normalize Windows hook command paths

### DIFF
--- a/src/nah/cli.py
+++ b/src/nah/cli.py
@@ -86,15 +86,24 @@ os._exit(0)
 '''
 
 
+def _shell_safe_path(pathlike: os.PathLike[str] | str) -> str:
+    """Normalize paths for hook shell commands across POSIX and Windows inputs."""
+    raw = os.fspath(pathlike)
+    if "\\" in raw:
+        return raw.replace("\\", "/")
+    return Path(raw).as_posix()
+
+
 def _hook_command() -> str:
     """Build the command string for settings.json hook entries."""
     # Use POSIX forward-slash paths: safe in both bash and cmd.exe on Windows.
     # shlex.quote() produces POSIX single-quoting which only works when the
     # command is interpreted by a POSIX shell. Claude Code may invoke hooks
     # via cmd.exe or direct OS spawn, where single quotes are literal chars.
-    # as_posix() eliminates backslashes at the source, sidestepping the issue.
-    exe = Path(sys.executable).as_posix()
-    script = _HOOK_SCRIPT.as_posix()
+    # Normalize Windows-looking inputs before quoting so mocked/interpolated
+    # interpreter paths do not leak backslashes on non-Windows hosts.
+    exe = _shell_safe_path(sys.executable)
+    script = _shell_safe_path(_HOOK_SCRIPT)
     return f'"{exe}" "{script}"'
 
 


### PR DESCRIPTION
## Summary

- Normalize `_hook_command()` inputs through a shared helper so Windows-style interpreter paths are rewritten with forward slashes even when tests run on POSIX hosts (`src/nah/cli.py`)
- Preserve existing POSIX behavior while keeping hook commands shell-safe for spaces and `shlex.split()` (`src/nah/cli.py`)
- `pytest tests/test_cli.py::TestHookCommand::test_windows_backslashes_converted -q -vv` now passes; the command no longer contains backslashes when `sys.executable` is mocked as `C:\Users\...\python.exe`

---
Category: tests | Priority: Med | Bead: `nah-a2n`

## Test plan

- [x] `pytest tests/test_cli.py::TestHookCommand::test_windows_backslashes_converted -q -vv` — 1 passed
- [x] `pytest tests/test_cli.py::TestHookCommand -q` — 3 passed
- [x] `pytest tests/ -q --tb=no` — 3225 passed, 7 failed, 22 skipped, 15 xfailed (baseline on `origin/main` was 3224 passed, 8 failed; no new regressions)

🤖 Generated by [autoharden](https://github.com/manuelschipper/nah)
