### PR TITLE
nah: add sensitive-path traversal regressions

### DIFF
--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -250,8 +250,23 @@ class TestCheckPath:
         assert result is not None
         assert result["decision"] == "block"
 
+    def test_sensitive_block_parent_traversal(self):
+        result = paths.check_path("Read", "~/.ssh/../.ssh/id_rsa")
+        assert result is not None
+        assert result["decision"] == "block"
+
+    def test_sensitive_block_home_env_with_parent_traversal(self):
+        result = paths.check_path("Read", "$HOME/.ssh/../.ssh/id_rsa")
+        assert result is not None
+        assert result["decision"] == "block"
+
     def test_sensitive_ask_home_glob(self):
         result = paths.check_path("Read", "/home/*/.aws/credentials")
+        assert result is not None
+        assert result["decision"] == "ask"
+
+    def test_sensitive_ask_parent_traversal(self):
+        result = paths.check_path("Read", "~/.aws/../.aws/credentials")
         assert result is not None
         assert result["decision"] == "ask"
 


### PR DESCRIPTION
## Summary

- Add regression coverage for parent-traversal spellings that normalize back into sensitive roots so future resolver changes cannot silently weaken policy enforcement (`tests/test_paths.py`)
- Verify `~/.ssh/../.ssh/id_rsa` and `$HOME/.ssh/../.ssh/id_rsa` remain `block`, and `~/.aws/../.aws/credentials` remains `ask` (policy behavior unchanged; test hardening only)

---
Category: tests | Priority: Med | Bead: `nah-wuj`

## Test plan

- [x] `pytest tests/test_paths.py::TestCheckPath -q` — 19 passed
- [x] `pytest tests/test_paths.py -q` — 85 passed
- [x] `pytest tests/ -q --tb=no` — 3227 passed, 8 failed, 22 skipped, 15 xfailed (same 8 baseline failures)
- [x] `/home/pn/.local/bin/nah test "cat ~/.ssh/../.ssh/id_rsa"` → BLOCK
- [x] `/home/pn/.local/bin/nah test "cat ~/.aws/../.aws/credentials"` → ASK
- [x] `/home/pn/.local/bin/nah test "cat $HOME/.ssh/../.ssh/id_rsa"` → BLOCK
