### PR TITLE
docs: sync action types table with nah types

### DIFF
--- a/site/configuration/actions.md
+++ b/site/configuration/actions.md
@@ -1,6 +1,6 @@
 # Action Types
 
-Every command nah classifies maps to one of 20 **action types**. Each type has a default **policy** that determines the decision.
+Every command nah classifies maps to one of 24 **action types**. Each type has a default **policy** that determines the decision.
 
 ## Policy levels
 
@@ -22,6 +22,7 @@ Policies are ordered by strictness. When merging configs, nah always keeps the s
 | `filesystem_delete` | context | Delete files or directories |
 | `git_safe` | allow | Read-only git operations (status, log, diff) |
 | `git_write` | allow | Git operations that modify the working tree or index |
+| `git_remote_write` | ask | Remote git mutations (gh pr merge, gh issue create, git push) |
 | `git_discard` | ask | Discard uncommitted changes (reset --hard, checkout .) |
 | `git_history_rewrite` | ask | Rewrite published history (force push, rebase -i) |
 | `network_outbound` | context | Outbound network requests (curl, wget, ssh) |
@@ -34,7 +35,10 @@ Policies are ordered by strictness. When merging configs, nah always keeps the s
 | `process_signal` | ask | Send signals to processes (kill, pkill) |
 | `container_destructive` | ask | Destructive container operations (docker rm, docker system prune) |
 | `db_read` | allow | Read-only database operations (SELECT, introspection) |
-| `db_write` | ask | Write operations on databases (INSERT, UPDATE, DELETE, DROP, ALTER) |
+| `db_write` | context | Write operations on databases (INSERT, UPDATE, DELETE, DROP, ALTER) |
+| `beads_safe` | allow | Read-only beads queries and diagnostics (bd list, bd show, bd ready) |
+| `beads_write` | allow | Beads workflow operations that modify data (bd create, bd update, bd close) |
+| `beads_destructive` | ask | Irreversible beads operations (bd delete, bd purge, bd admin) |
 | `obfuscated` | block | Obfuscated or encoded commands (base64 \| bash) |
 | `unknown` | ask | Unrecognized command or tool -- not in any classify table |
 


### PR DESCRIPTION
## Summary

- Update `site/configuration/actions.md` to match current `nah types` output (`site/configuration/actions.md`)
- Correct action-type count (20 → 24), add missing `git_remote_write` and `beads_*` rows, and fix `db_write` default (`ask` → `context`)
- Prevent docs/config drift so users see accurate default-policy guidance when overriding actions

---
Category: docs | Priority: Med | Bead: `nah-nye`

## Test plan

- [x] `/home/pn/.local/bin/nah types`
- [x] `python3` parity check of action-type/default-policy rows in `site/configuration/actions.md` against `nah types` output
- [x] `pytest tests/ -q --tb=no` — 3224 passed, 8 failed, 22 skipped, 15 xfailed (same baseline failures)
