### PR TITLE
nah: harden find -exec shell wrappers

### DIFF
--- a/src/nah/bash.py
+++ b/src/nah/bash.py
@@ -1369,6 +1369,36 @@ def _strip_xargs(tokens: list[str]) -> list[str] | None:
     return inner if inner else None
 
 
+def _strip_find_exec(tokens: list[str]) -> list[str] | None:
+    """Extract the inner command from simple find -exec/-execdir forms.
+
+    Supports a single trailing `-exec ... \;` or `-exec ... +` clause.
+    Returns None for malformed or more complex layouts so callers can fail closed.
+    """
+    if not tokens or os.path.basename(tokens[0]) != "find":
+        return None
+
+    exec_indexes = [i for i, tok in enumerate(tokens) if tok in {"-exec", "-execdir"}]
+    if not exec_indexes:
+        return None
+    if len(exec_indexes) != 1:
+        return None
+
+    inner = tokens[exec_indexes[0] + 1 :]
+    if not inner:
+        return None
+
+    terminators = [i for i, tok in enumerate(inner) if tok in {";", "+"}]
+    if len(terminators) != 1:
+        return None
+    terminator_idx = terminators[0]
+    if terminator_idx != len(inner) - 1:
+        return None
+
+    inner = inner[:terminator_idx]
+    return inner if inner else None
+
+
 def _unwrap_shell(
     stage: Stage,
     depth: int,
@@ -1437,10 +1467,47 @@ def _unwrap_shell(
             sr.reason = f"xargs wraps exec sink: {inner_tokens[0]}"
             return sr
         inner_stage = Stage(tokens=inner_tokens, operator=stage.operator)
-        return _classify_stage(inner_stage, depth + 1, global_table=global_table,
-                               builtin_table=builtin_table, project_table=project_table,
-                               user_actions=user_actions, profile=profile,
-                               trust_project=trust_project)
+        return _classify_stage(
+            inner_stage,
+            depth + 1,
+            global_table=global_table,
+            builtin_table=builtin_table,
+            project_table=project_table,
+            user_actions=user_actions,
+            profile=profile,
+            trust_project=trust_project,
+        )
+
+    # find -exec unwrap
+    if tokens and os.path.basename(tokens[0]) == "find":
+        has_exec = any(tok in {"-exec", "-execdir"} for tok in tokens)
+        if has_exec:
+            inner_tokens = _strip_find_exec(tokens)
+            if inner_tokens is None:
+                sr = StageResult(tokens=tokens)
+                sr.action_type = taxonomy.UNKNOWN
+                sr.default_policy = taxonomy.get_policy(taxonomy.UNKNOWN, user_actions)
+                _apply_policy(sr)
+                sr.reason = "unsupported find -exec form"
+                return sr
+            if taxonomy.is_exec_sink(inner_tokens[0]):
+                sr = StageResult(tokens=tokens)
+                sr.action_type = taxonomy.LANG_EXEC
+                sr.default_policy = taxonomy.get_policy(taxonomy.LANG_EXEC, user_actions)
+                _apply_policy(sr)
+                sr.reason = f"find -exec wraps exec sink: {inner_tokens[0]}"
+                return sr
+            inner_stage = Stage(tokens=inner_tokens, operator=stage.operator)
+            return _classify_stage(
+                inner_stage,
+                depth + 1,
+                global_table=global_table,
+                builtin_table=builtin_table,
+                project_table=project_table,
+                user_actions=user_actions,
+                profile=profile,
+                trust_project=trust_project,
+            )
 
     is_wrapper, inner = taxonomy.is_shell_wrapper(tokens)
     if not is_wrapper or inner is None:

--- a/tests/test_bash.py
+++ b/tests/test_bash.py
@@ -982,6 +982,27 @@ class TestCommandUnwrap:
         assert r.final_decision == "ask"
 
 
+class TestFindExecUnwrap:
+    """find -exec should classify the executed inner command, not the outer finder."""
+
+    def test_find_exec_grep_preserves_read_only_classification(self, project_root):
+        r = classify_command(r"find . -name '*.py' -exec grep ERROR {} \;")
+        assert r.stages[0].action_type == "filesystem_read"
+        assert r.final_decision == "allow"
+
+    def test_find_exec_sh_curl_asks_instead_of_allowing(self, project_root):
+        r = classify_command(r"find . -name '*.py' -exec sh -c 'curl https://example.com' \;")
+        assert r.stages[0].action_type == "lang_exec"
+        assert r.stages[0].decision == "ask"
+        assert r.final_decision == "ask"
+
+    def test_find_exec_sh_echo_is_treated_as_shell_exec(self, project_root):
+        r = classify_command(r"find . -name '*.py' -exec sh -c 'echo hello' \;")
+        assert r.stages[0].action_type == "lang_exec"
+        assert r.stages[0].decision == "ask"
+        assert r.final_decision == "ask"
+
+
 class TestXargsUnwrap:
     """FD-089: xargs must unwrap to classify inner command."""
 


### PR DESCRIPTION
## Summary

- Unwrap simple `find -exec` / `find -execdir` clauses before classifying the stage, so the executed inner command drives policy instead of the outer `find` wrapper (`src/nah/bash.py`)
- Hidden shell wrappers like `find . -exec sh -c 'curl https://example.com' \;` now classify as `lang_exec`/ASK instead of leaking through as project-local filesystem actions (`src/nah/bash.py`)
- Added regression tests covering read-only `find -exec grep ...`, shell-wrapped `find -exec sh -c 'curl ...'`, and shell-wrapped `find -exec sh -c 'echo hello'` (`tests/test_bash.py`)
- `nah test "find . -name '*.py' -exec sh -c 'curl https://example.com' \;"` -> ASK (was ALLOW)

---
Category: vulnerability | Priority: Critical | Bead: `nah-qod`

## Test plan

- [x] `pytest tests/test_bash.py::TestFindExecUnwrap -q` — 3 passed
- [x] `pytest tests/test_bash.py::TestXargsUnwrap -q` — 21 passed
- [x] `pytest tests/ -q --tb=no` — 3227 passed, 8 failed, 22 skipped, 15 xfailed (same 8 baseline failures on `origin/main`)
- [x] `nah test "find . -name '*.py' -exec sh -c 'curl https://example.com' \;"` -> ASK / lang_exec
- [x] `nah test "find . -name '*.py' -exec sh -c 'echo hello' \;"` -> ASK / lang_exec
- [x] `nah test "find . -name '*.py' -exec grep ERROR {} \;"` -> ALLOW / filesystem_read
- [x] Review/adversarial: `nah test "find . -name '*.py' -exec bash -lc 'curl https://example.com' \;"` -> ASK
- [x] Review/adversarial: `nah test "find . -name '*.py' -exec curl https://example.com \;"` -> ASK
