### PR TITLE
nah: classify gh api GET/HEAD separately

### DIFF
--- a/src/nah/taxonomy.py
+++ b/src/nah/taxonomy.py
@@ -111,7 +111,7 @@ def build_user_table(user_classify: dict[str, list[str]]) -> list[tuple[tuple[st
 
 # Commands with Phase 2 flag classifiers (flag-dependent classification).
 _FLAG_CLASSIFIER_CMDS = {"find", "sed", "awk", "gawk", "mawk", "nawk",
-                          "tar", "git", "curl", "wget",
+                          "tar", "git", "gh", "curl", "wget",
                           "http", "https", "xh", "xhs",
                           "npm", "pnpm", "bun", "pip", "pip3", "cargo", "gem",
                           "python", "python3", "node", "ruby", "perl",
@@ -380,6 +380,9 @@ def classify_tokens(
             action = _classify_git(tokens)
             if action is not None:
                 return action
+        action = _classify_gh_api(tokens)
+        if action is not None:
+            return action
         action = _classify_curl(tokens)
         if action is not None:
             return action
@@ -971,6 +974,82 @@ def _classify_git(tokens: list[str]) -> str | None:
         return GIT_WRITE if "--staged" in args else GIT_DISCARD
 
     return None
+
+
+_GH_API_WRITE_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+_GH_API_SAFE_METHODS = {"GET", "HEAD"}
+_GH_API_METHOD_FLAGS = {"--method", "-X"}
+_GH_API_PAYLOAD_FLAGS = {"--field", "-F", "--raw-field", "-f", "--input"}
+
+
+def _classify_gh_api(tokens: list[str]) -> str | None:
+    """Flag-dependent classification for `gh api`.
+
+    Read-only REST requests default to git_safe. Explicit write methods and
+    implicit-body forms (`--field`, `--raw-field`, `--input`) escalate to
+    git_remote_write. GraphQL and ambiguous method forms fall back to the
+    existing conservative `gh api` lang_exec rule.
+    """
+    if len(tokens) < 2 or tokens[0] != "gh" or tokens[1] != "api":
+        return None
+
+    args = tokens[2:]
+    explicit_method: str | None = None
+    has_payload = False
+    endpoint: str | None = None
+
+    i = 0
+    while i < len(args):
+        tok = args[i]
+
+        if tok in _GH_API_METHOD_FLAGS:
+            if i + 1 >= len(args):
+                return None
+            explicit_method = args[i + 1].upper()
+            i += 2
+            continue
+        if tok.startswith("--method="):
+            explicit_method = tok.split("=", 1)[1].upper()
+            i += 1
+            continue
+
+        if tok in _GH_API_PAYLOAD_FLAGS:
+            has_payload = True
+            if i + 1 >= len(args):
+                return None
+            i += 2
+            continue
+        if (
+            tok.startswith("--field=")
+            or tok.startswith("--raw-field=")
+            or tok.startswith("--input=")
+        ):
+            has_payload = True
+            i += 1
+            continue
+
+        if tok.startswith("-"):
+            i += 1
+            continue
+
+        if endpoint is None:
+            endpoint = tok
+        i += 1
+
+    if endpoint == "graphql":
+        return None
+
+    if explicit_method in _GH_API_SAFE_METHODS:
+        return GIT_SAFE
+    if explicit_method in _GH_API_WRITE_METHODS:
+        return GIT_REMOTE_WRITE
+    if explicit_method is not None:
+        return None
+    if has_payload:
+        return GIT_REMOTE_WRITE
+    if endpoint is None:
+        return None
+    return GIT_SAFE
 
 
 def load_type_descriptions() -> dict[str, str]:

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -61,6 +61,15 @@ class TestClassifyTokens:
     def test_git_safe(self, tokens):
         assert _ct(tokens) == "git_safe"
 
+    @pytest.mark.parametrize("tokens", [
+        ["gh", "api", "repos/manuelschipper/nah/pulls?state=open"],
+        ["gh", "api", "--method", "GET", "repos/manuelschipper/nah/pulls?state=open"],
+        ["gh", "api", "-X", "HEAD", "repos/manuelschipper/nah"],
+        ["gh", "api", "--method", "GET", "repos/manuelschipper/nah/issues", "-F", "state=open"],
+    ])
+    def test_gh_api_read_only_requests_are_git_safe(self, tokens):
+        assert _ct(tokens) == "git_safe"
+
     # git_write
     @pytest.mark.parametrize("tokens", [
         ["git", "add", "."],
@@ -78,6 +87,19 @@ class TestClassifyTokens:
     # git_remote_write
     def test_git_push_remote_write(self):
         assert _ct(["git", "push"]) == "git_remote_write"
+
+    @pytest.mark.parametrize("tokens", [
+        ["gh", "api", "--method", "POST", "repos/manuelschipper/nah/issues"],
+        ["gh", "api", "--method=PATCH", "repos/manuelschipper/nah/issues/1"],
+        ["gh", "api", "repos/manuelschipper/nah/issues", "-F", "title=test"],
+        ["gh", "api", "repos/manuelschipper/nah/issues", "--raw-field", "title=test"],
+        ["gh", "api", "repos/manuelschipper/nah/issues", "--input", "body.json"],
+    ])
+    def test_gh_api_writes_are_git_remote_write(self, tokens):
+        assert _ct(tokens) == "git_remote_write"
+
+    def test_gh_api_graphql_stays_conservative_lang_exec(self):
+        assert _ct(["gh", "api", "graphql", "-f", "query=query { viewer { login } }"]) == "lang_exec"
 
     # git_history_rewrite
     @pytest.mark.parametrize("tokens", [
@@ -1277,9 +1299,9 @@ class TestGhCommands:
     def test_gh_filesystem_write(self, tokens):
         assert _ct(tokens) == "filesystem_write"
 
-    # lang_exec — runs arbitrary code
+    # lang_exec — runs arbitrary code or conservative gh api fallbacks
     @pytest.mark.parametrize("tokens", [
-        ["gh", "api", "/repos/owner/repo"],
+        ["gh", "api", "graphql", "-f", "query=query { viewer { login } }"],
         ["gh", "extension", "exec", "my-ext"],
     ])
     def test_gh_lang_exec(self, tokens):


### PR DESCRIPTION
## Summary

- Add a Phase 2 `gh api` classifier that treats REST GET/HEAD requests as `git_safe`, routes explicit or implicit write requests to `git_remote_write`, and leaves GraphQL on the conservative fallback (`src/nah/taxonomy.py`)
- `gh api repos/manuelschipper/nah/pulls?state=open` now classifies as ALLOW / `git_safe` instead of the coarse `lang_exec` ASK fallback (`src/nah/taxonomy.py`)
- `gh api --method POST repos/manuelschipper/nah/issues` and implicit body forms like `-F title=test` now classify as ASK / `git_remote_write` (`src/nah/taxonomy.py`, `tests/test_taxonomy.py`)
- Add regression coverage for safe REST reads, mutating REST requests, and the unchanged GraphQL conservative path (`tests/test_taxonomy.py`)

---
Category: taxonomy | Priority: Med | Bead: `nah-pdg`

## Test plan

- [x] `pytest tests/test_taxonomy.py -q` — 1315 passed
- [x] `pytest tests/ -q --tb=no` — 3234 passed, 8 failed, 22 skipped, 15 xfailed (same 8 baseline failures)
- [x] `/home/pn/.local/bin/nah test "gh api repos/manuelschipper/nah/pulls?state=open"` → ALLOW / `git_safe`
- [x] `/home/pn/.local/bin/nah test "gh api --method POST repos/manuelschipper/nah/issues"` → ASK / `git_remote_write`
- [x] `/home/pn/.local/bin/nah test "gh api graphql -f query='query { viewer { login } }'"` → ASK (unchanged conservative fallback)
