### PR TITLE
nah: block reads of /etc/shadow as sensitive path

### DIFF
--- a/src/nah/paths.py
+++ b/src/nah/paths.py
@@ -28,6 +28,7 @@ _SENSITIVE_DIRS: list[tuple[str, str, str]] = [
     (os.path.realpath(os.path.join(_HOME, ".terraformrc")), "~/.terraformrc", "ask"),
     (os.path.realpath(os.path.join(_HOME, ".claude", "settings.json")), "~/.claude/settings.json", "ask"),
     (os.path.realpath(os.path.join(_HOME, ".claude", "settings.local.json")), "~/.claude/settings.local.json", "ask"),
+    (os.path.realpath("/etc/shadow"), "/etc/shadow", "block"),
 ]
 
 # Basename patterns: (basename, display_name, policy)

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -589,3 +589,9 @@ class TestSettingsJsonProtection:
         resolved = paths.resolve_path("~/.claude/settings.json")
         matched, _, _ = paths.is_sensitive(resolved)
         assert matched is False
+
+
+def test_sensitive_system_shadow_is_blocked() -> None:
+    paths.reset_sensitive_paths()
+    decision = paths.check_path_basic_raw("/etc/shadow")
+    assert decision == ("block", "targets sensitive path: /etc/shadow")


### PR DESCRIPTION
## Category
vulnerability

## Priority
High

## Problem
cat /etc/shadow and wrapped variants were allowed as filesystem_read.

## Solution
Added /etc/shadow to sensitive path blocklist and regression test.

## Test Results
83 passed in tests/test_paths.py; nah test 'cat /etc/shadow' -> BLOCK

## Bead
n/a (bd unavailable in this environment)