### PR TITLE
Fix nah invocation on Windows. Add tests to cover updated functionality.

### DIFF
--- a/src/nah/cli.py
+++ b/src/nah/cli.py
@@ -15,6 +15,7 @@ _HOOK_SCRIPT = _HOOKS_DIR / "nah_guard.py"
 
 _SHIM_TEMPLATE = '''\
 #!{interpreter}
+# -*- coding: utf-8 -*-
 """nah guard — thin shim that imports from the installed nah package."""
 import sys, json, os, io
 
@@ -169,18 +170,19 @@ def _write_hook_script() -> None:
     # Skip write if content is identical
     if _HOOK_SCRIPT.exists():
         try:
-            if _HOOK_SCRIPT.read_text() == shim_content:
+            if _HOOK_SCRIPT.read_text(encoding="utf-8") == shim_content:
                 return
-        except OSError:
+        except (OSError, UnicodeDecodeError):
             # Read is best-effort optimization; if it fails (race with
-            # deletion, permissions, disk), the safe default is to fall
-            # through to the write path which will surface real errors.
+            # deletion, permissions, disk, or encoding mismatch from a
+            # pre-UTF-8 install), the safe default is to fall through to
+            # the write path which will surface real errors.
             pass
 
     if _HOOK_SCRIPT.exists():
         os.chmod(_HOOK_SCRIPT, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
 
-    with open(_HOOK_SCRIPT, "w") as f:
+    with open(_HOOK_SCRIPT, "w", encoding="utf-8") as f:
         f.write(shim_content)
 
     os.chmod(_HOOK_SCRIPT, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)  # 444
@@ -265,13 +267,17 @@ def cmd_update(args: argparse.Namespace) -> None:
                 if _is_nah_hook(entry):
                     entry["hooks"] = [{"type": "command", "command": command}]
                     updated += 1
-                    # Add missing tool matchers from current AGENT_TOOL_MATCHERS
-                    expected = set(agents.AGENT_TOOL_MATCHERS.get(key, []))
-                    current = set(entry.get("matcher", {}).get("tool_name", []))
-                    missing = expected - current
-                    if missing:
-                        entry.setdefault("matcher", {})["tool_name"] = sorted(current | expected)
-                        added_matchers = len(missing)
+                    # Add missing tool matchers from current AGENT_TOOL_MATCHERS.
+                    # Only applies to object-style matchers ({"tool_name": [...]});
+                    # string-style matchers ("Bash") use one entry per tool.
+                    matcher = entry.get("matcher")
+                    if isinstance(matcher, dict):
+                        expected = set(agents.AGENT_TOOL_MATCHERS.get(key, []))
+                        current = set(matcher.get("tool_name", []))
+                        missing = expected - current
+                        if missing:
+                            matcher["tool_name"] = sorted(current | expected)
+                            added_matchers = len(missing)
             if updated:
                 _write_settings(settings_file, settings)
                 msg = f"{updated} hooks updated"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -619,3 +619,121 @@ class TestHookCommand:
         assert len(parts) == 2
         assert "my python" in parts[0]
         assert "my user" in parts[1]
+
+
+class TestWriteHookScriptEncoding:
+    """Hook shim must be written and read as UTF-8 on all platforms."""
+
+    def test_shim_has_utf8_coding_cookie(self):
+        """Shim template includes coding declaration for Windows Python."""
+        import nah.cli as cli_mod
+        assert "# -*- coding: utf-8 -*-" in cli_mod._SHIM_TEMPLATE
+
+    def test_hook_written_as_utf8(self, tmp_path, monkeypatch):
+        """Hook file is valid UTF-8 containing em-dash characters."""
+        import nah.cli as cli_mod
+        hook_path = tmp_path / "nah_guard.py"
+        monkeypatch.setattr(cli_mod, "_HOOKS_DIR", tmp_path)
+        monkeypatch.setattr(cli_mod, "_HOOK_SCRIPT", hook_path)
+
+        cli_mod._write_hook_script()
+
+        raw = hook_path.read_bytes()
+        text = raw.decode("utf-8")
+        assert "\u2014" in text  # em-dash survives round-trip
+
+    def test_skip_write_tolerates_non_utf8_existing(self, tmp_path, monkeypatch):
+        """If an old hook was written in cp1252, _write_hook_script overwrites it."""
+        import nah.cli as cli_mod
+        hook_path = tmp_path / "nah_guard.py"
+        monkeypatch.setattr(cli_mod, "_HOOKS_DIR", tmp_path)
+        monkeypatch.setattr(cli_mod, "_HOOK_SCRIPT", hook_path)
+
+        # Write a cp1252-encoded file (em-dash is 0x97 in cp1252)
+        hook_path.write_bytes("old \x97 content".encode("latin-1"))
+        hook_path.chmod(0o444)
+
+        cli_mod._write_hook_script()
+
+        text = hook_path.read_text(encoding="utf-8")
+        assert "nah guard" in text
+
+
+class TestCmdUpdateMatchers:
+    """cmd_update must handle both string and object matcher formats."""
+
+    def _make_settings(self, tmp_path, monkeypatch, matchers):
+        """Helper: write settings.json with given PreToolUse entries."""
+        import json as json_mod
+        import nah.cli as cli_mod
+        from nah import agents
+
+        settings_file = tmp_path / "settings.json"
+        settings_data = {"hooks": {"PreToolUse": matchers}}
+        settings_file.write_text(json_mod.dumps(settings_data))
+        monkeypatch.setattr(agents, "AGENT_SETTINGS", {agents.CLAUDE: settings_file})
+        monkeypatch.setattr(cli_mod, "_HOOKS_DIR", tmp_path / "hooks")
+        monkeypatch.setattr(cli_mod, "_HOOK_SCRIPT", tmp_path / "hooks" / "nah_guard.py")
+        return settings_file
+
+    def test_string_matchers_update_command(self, tmp_path, monkeypatch):
+        """String-style matchers get their command updated without crashing."""
+        import json as json_mod
+        import nah.cli as cli_mod
+
+        entries = [
+            {"matcher": "Bash", "hooks": [{"type": "command", "command": "old nah_guard.py"}]},
+            {"matcher": "Read", "hooks": [{"type": "command", "command": "old nah_guard.py"}]},
+        ]
+        sf = self._make_settings(tmp_path, monkeypatch, entries)
+        cli_mod._write_hook_script()
+
+        args = argparse.Namespace(agent=None)
+        cli_mod.cmd_update(args)
+
+        updated = json_mod.loads(sf.read_text())
+        for entry in updated["hooks"]["PreToolUse"]:
+            assert "old" not in entry["hooks"][0]["command"]
+
+    def test_string_matchers_adds_missing_tools(self, tmp_path, monkeypatch):
+        """Update adds entries for tools in AGENT_TOOL_MATCHERS but missing from settings."""
+        import json as json_mod
+        import nah.cli as cli_mod
+        from nah import agents
+
+        # Only install one tool; the rest should be added by update
+        entries = [
+            {"matcher": "Bash", "hooks": [{"type": "command", "command": "old nah_guard.py"}]},
+        ]
+        sf = self._make_settings(tmp_path, monkeypatch, entries)
+        cli_mod._write_hook_script()
+
+        args = argparse.Namespace(agent=None)
+        cli_mod.cmd_update(args)
+
+        updated = json_mod.loads(sf.read_text())
+        tool_names = [e["matcher"] for e in updated["hooks"]["PreToolUse"]]
+        expected = agents.AGENT_TOOL_MATCHERS[agents.CLAUDE]
+        for tool in expected:
+            assert tool in tool_names, f"{tool} not added by update"
+
+    def test_object_matchers_still_work(self, tmp_path, monkeypatch):
+        """Object-style matchers ({tool_name: [...]}) still get merged correctly."""
+        import json as json_mod
+        import nah.cli as cli_mod
+        from nah import agents
+
+        entries = [
+            {"matcher": {"tool_name": ["Bash"]},
+             "hooks": [{"type": "command", "command": "old nah_guard.py"}]},
+        ]
+        sf = self._make_settings(tmp_path, monkeypatch, entries)
+        cli_mod._write_hook_script()
+
+        args = argparse.Namespace(agent=None)
+        cli_mod.cmd_update(args)
+
+        updated = json_mod.loads(sf.read_text())
+        entry = updated["hooks"]["PreToolUse"][0]
+        assert isinstance(entry["matcher"], dict)
+        assert set(entry["matcher"]["tool_name"]) >= set(agents.AGENT_TOOL_MATCHERS[agents.CLAUDE])


### PR DESCRIPTION
# Summary
- Fix Windows encoding crash in hook shim: write/read with explicit encoding="utf-8" and add # -*- coding: utf-8 -*- source cookie so Python parses em-dash characters correctly regardless of system locale
- Fix nah update crash on string-style matchers ("matcher": "Bash") — the code assumed object-style ("matcher": {"tool_name": [...]}) which the installer never produces
- Ensure nah update adds hook entries for new tools introduced in newer versions (e.g. MultiEdit, NotebookEdit), which previously never worked due to the crash
- Add 6 tests covering UTF-8 round-tripping, cp1252 tolerance, and both matcher formats

# Changed files
- src/nah/cli.py — encoding fixes in _write_hook_script(), matcher handling in cmd_update()
- tests/test_cli.py — TestWriteHookScriptEncoding (3 tests), TestCmdUpdateMatchers (3 tests)

# Test plan
- TestWriteHookScriptEncoding::test_shim_has_utf8_coding_cookie — template includes coding declaration
- TestWriteHookScriptEncoding::test_hook_written_as_utf8 — em-dash survives write/read round-trip
- TestWriteHookScriptEncoding::test_skip_write_tolerates_non_utf8_existing — cp1252 file gets overwritten
- TestCmdUpdateMatchers::test_string_matchers_update_command — string matchers update without crash
- TestCmdUpdateMatchers::test_string_matchers_adds_missing_tools — new tools added on update
- TestCmdUpdateMatchers::test_object_matchers_still_work — object matchers still merge correctly
- Manual: nah update succeeds on Windows with existing string-style settings

By submitting this pull request, I confirm that I have read and agree to the [Contributor License Agreement](../CLA.md).
