### PR TITLE
fix: add flag classifier for gh api — stop lang_exec misclassification

### DIFF
--- a/src/nah/data/classify_full/lang_exec.json
+++ b/src/nah/data/classify_full/lang_exec.json
@@ -7,6 +7,5 @@
   "ruby -e",
   "perl -e",
   "php -r",
-  "gh api",
   "gh extension exec"
 ]

--- a/src/nah/taxonomy.py
+++ b/src/nah/taxonomy.py
@@ -389,6 +389,9 @@ def classify_tokens(
         action = _classify_httpie(tokens)
         if action is not None:
             return action
+        action = _classify_gh(tokens)
+        if action is not None:
+            return action
         action = _classify_global_install(tokens)
         if action is not None:
             return action
@@ -796,6 +799,93 @@ def _classify_httpie(tokens: list[str]) -> str | None:
     if has_data_item:
         return NETWORK_WRITE
     return NETWORK_OUTBOUND
+
+
+# gh api: flags that send a request body (gh defaults to POST when present).
+_GH_API_DATA_FLAGS = {"-f", "-F", "--raw-field", "--field", "--input"}
+_GH_API_DATA_JOINED_PREFIXES = ("-f=", "-F=", "--raw-field=", "--field=", "--input=")
+_GH_API_METHOD_FLAGS = {"-X", "--method"}
+# Separated from _WRITE_METHODS — DELETE maps to git_history_rewrite (irreversible).
+_GH_API_DESTRUCTIVE_METHODS = {"DELETE"}
+_GH_API_SAFE_METHODS = {"GET", "HEAD"}
+
+
+def _classify_gh(tokens: list[str]) -> str | None:
+    """Flag-dependent: gh api with write flags -> git_write; without -> git_safe.
+
+    Only handles ``gh api`` subcommand.  Other ``gh`` subcommands (pr, issue,
+    search ...) are left to prefix tables and return *None*.
+    """
+    if len(tokens) < 2 or tokens[0] != "gh":
+        return None
+
+    # Early return: --help/-h on ANY gh command is safe (not just gh api).
+    # gh uses -h for help (unlike curl where -h is --header).
+    if "--help" in tokens or "-h" in tokens:
+        return GIT_SAFE
+
+    if tokens[1] != "api":
+        return None
+
+    has_data = False
+    has_write_method = False
+    has_destructive_method = False
+    has_safe_method = False
+
+    i = 2  # skip "gh api"
+    while i < len(tokens):
+        tok = tokens[i]
+
+        # Standalone data flags (-f, -F, --field, --raw-field, --input)
+        if tok in _GH_API_DATA_FLAGS:
+            has_data = True
+            i += 2  # skip flag + value
+            continue
+
+        # Joined data flags: --raw-field=KEY=VALUE, --field=KEY=VALUE, --input=FILE
+        if any(tok.startswith(p) for p in _GH_API_DATA_JOINED_PREFIXES):
+            has_data = True
+            i += 1
+            continue
+
+        # Method flags: -X METHOD, --method METHOD
+        if tok in _GH_API_METHOD_FLAGS:
+            if i + 1 < len(tokens):
+                method = tokens[i + 1].upper()
+                if method in _GH_API_DESTRUCTIVE_METHODS:
+                    has_destructive_method = True
+                elif method in _WRITE_METHODS:
+                    has_write_method = True
+                elif method in _GH_API_SAFE_METHODS:
+                    has_safe_method = True
+            i += 2
+            continue
+
+        # Joined method flag: --method=DELETE
+        if tok.startswith("--method="):
+            method = tok.split("=", 1)[1].upper()
+            if method in _GH_API_DESTRUCTIVE_METHODS:
+                has_destructive_method = True
+            elif method in _WRITE_METHODS:
+                has_write_method = True
+            elif method in _GH_API_SAFE_METHODS:
+                has_safe_method = True
+            i += 1
+            continue
+
+        i += 1
+
+    # DELETE is irreversible — treated as git_history_rewrite, analogous to
+    # gh repo/issue delete in the prefix tables.
+    if has_destructive_method:
+        return GIT_HISTORY_REWRITE
+    # Explicit write method (-X POST/PUT/PATCH) escalates even without data flags.
+    if has_write_method:
+        return GIT_WRITE
+    # Data flags (-f/-F) imply POST unless overridden by -X GET/HEAD.
+    if has_data and not has_safe_method:
+        return GIT_WRITE
+    return GIT_SAFE
 
 
 def _classify_global_install(tokens: list[str]) -> str | None:

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -1279,11 +1279,83 @@ class TestGhCommands:
 
     # lang_exec — runs arbitrary code
     @pytest.mark.parametrize("tokens", [
-        ["gh", "api", "/repos/owner/repo"],
         ["gh", "extension", "exec", "my-ext"],
     ])
     def test_gh_lang_exec(self, tokens):
         assert _ct(tokens) == "lang_exec"
+
+    # gh api — flag classifier (Phase 2) distinguishes read vs write vs destructive
+    @pytest.mark.parametrize("tokens,expected", [
+        # --- git_safe: read-only ---
+        pytest.param(["gh", "api", "/repos/owner/repo"], "git_safe", id="bare-endpoint"),
+        pytest.param(["gh", "api", "repos/owner/repo", "--jq", ".name"], "git_safe", id="jq-filter"),
+        pytest.param(["gh", "api", "repos/owner/repo", "--paginate"], "git_safe", id="paginate"),
+        pytest.param(["gh", "api"], "git_safe", id="bare-api-no-endpoint"),
+        # Explicit safe methods (-X GET, -X HEAD, --method GET, --method=GET)
+        pytest.param(["gh", "api", "repos/owner/repo", "-X", "GET"], "git_safe", id="explicit-GET"),
+        pytest.param(["gh", "api", "repos/owner/repo", "--method", "GET"], "git_safe", id="method-GET"),
+        pytest.param(["gh", "api", "repos/owner/repo", "--method=GET"], "git_safe", id="method-joined-GET"),
+        pytest.param(["gh", "api", "repos/owner/repo", "-X", "HEAD"], "git_safe", id="explicit-HEAD"),
+        pytest.param(["gh", "api", "repos/owner/repo", "--method", "HEAD"], "git_safe", id="method-HEAD"),
+        pytest.param(["gh", "api", "repos/owner/repo", "--method=HEAD"], "git_safe", id="method-joined-HEAD"),
+        # Data flags with explicit safe method → query params, not a write
+        pytest.param(["gh", "api", "repos/owner/repo", "-X", "GET", "-f", "per_page=100"], "git_safe", id="GET-with-f"),
+        pytest.param(["gh", "api", "repos/owner/repo", "-f", "per_page=100", "-X", "GET"], "git_safe", id="f-then-GET"),
+        pytest.param(["gh", "api", "repos/owner/repo", "--method=GET", "-f", "per_page=100"], "git_safe", id="method-joined-GET-with-f"),
+        pytest.param(["gh", "api", "repos/owner/repo", "-X", "HEAD", "-f", "per_page=100"], "git_safe", id="HEAD-with-f"),
+        pytest.param(["gh", "api", "repos/owner/repo", "--jq", "[.]", "-X", "GET", "-f", "per_page=100", "-f", "since=2025-01-01"], "git_safe", id="GET-multi-f-jq"),
+        # Unknown method defaults safe
+        pytest.param(["gh", "api", "repos/owner/repo", "-X", "FOOBAR"], "git_safe", id="unknown-method"),
+        # --- git_write: mutating (POST/PUT/PATCH) ---
+        # Standalone data flags (each triggers implicit POST)
+        pytest.param(["gh", "api", "repos/owner/repo/issues", "-f", "title=bug"], "git_write", id="data-f"),
+        pytest.param(["gh", "api", "repos/owner/repo/issues", "-F", "title=bug"], "git_write", id="data-F"),
+        pytest.param(["gh", "api", "repos/owner/repo/issues", "--field", "title=bug"], "git_write", id="data-field"),
+        pytest.param(["gh", "api", "repos/owner/repo/issues", "--raw-field", "body=hello"], "git_write", id="data-raw-field"),
+        pytest.param(["gh", "api", "repos/owner/repo/issues", "--input", "body.json"], "git_write", id="data-input"),
+        # Data flag before endpoint
+        pytest.param(["gh", "api", "-f", "title=bug", "repos/owner/repo/issues"], "git_write", id="f-before-endpoint"),
+        # Joined data flags
+        pytest.param(["gh", "api", "repos/owner/repo", "-f=key=val"], "git_write", id="joined-f"),
+        pytest.param(["gh", "api", "repos/owner/repo", "-F=key=val"], "git_write", id="joined-F"),
+        pytest.param(["gh", "api", "repos/owner/repo", "--field=body=test"], "git_write", id="joined-field"),
+        pytest.param(["gh", "api", "graphql", "--raw-field=query={viewer{login}}"], "git_write", id="joined-raw-field"),
+        pytest.param(["gh", "api", "repos/owner/repo", "--input=body.json"], "git_write", id="joined-input"),
+        # Explicit write methods (without data flags)
+        pytest.param(["gh", "api", "repos/owner/repo", "-X", "POST"], "git_write", id="explicit-POST"),
+        pytest.param(["gh", "api", "repos/owner/repo", "-X", "PUT"], "git_write", id="explicit-PUT"),
+        pytest.param(["gh", "api", "repos/owner/repo", "-X", "PATCH"], "git_write", id="explicit-PATCH"),
+        pytest.param(["gh", "api", "repos/owner/repo", "--method", "POST"], "git_write", id="method-POST"),
+        pytest.param(["gh", "api", "repos/owner/repo", "--method=POST"], "git_write", id="method-joined-POST"),
+        pytest.param(["gh", "api", "repos/owner/repo", "--method=PATCH"], "git_write", id="method-joined-PATCH"),
+        # Write method + data flag
+        pytest.param(["gh", "api", "repos/owner/repo", "-X", "POST", "-f", "title=bug"], "git_write", id="POST-with-f"),
+        # --- git_history_rewrite: destructive (DELETE) ---
+        pytest.param(["gh", "api", "repos/owner/repo", "-X", "DELETE"], "git_history_rewrite", id="explicit-DELETE"),
+        pytest.param(["gh", "api", "-X", "DELETE", "repos/owner/repo"], "git_history_rewrite", id="DELETE-before-endpoint"),
+        pytest.param(["gh", "api", "repos/owner/repo", "--method", "DELETE"], "git_history_rewrite", id="method-DELETE"),
+        pytest.param(["gh", "api", "repos/owner/repo", "--method=DELETE"], "git_history_rewrite", id="method-joined-DELETE"),
+        # DELETE + data flag: destructive wins
+        pytest.param(["gh", "api", "repos/owner/repo", "-X", "DELETE", "-f", "confirm=true"], "git_history_rewrite", id="DELETE-with-f"),
+        # --- Boundary: truncated method flag with no following token ---
+        pytest.param(["gh", "api", "repos/owner/repo", "-X"], "git_safe", id="truncated-X"),
+        pytest.param(["gh", "api", "repos/owner/repo", "--method"], "git_safe", id="truncated-method"),
+    ])
+    def test_gh_api_flag_classifier(self, tokens, expected):
+        assert _ct(tokens) == expected
+
+    # gh --help — always safe regardless of subcommand or other flags
+    @pytest.mark.parametrize("tokens", [
+        pytest.param(["gh", "--help"], id="gh-help"),
+        pytest.param(["gh", "api", "--help"], id="api-help"),
+        pytest.param(["gh", "pr", "--help"], id="pr-help"),
+        pytest.param(["gh", "repo", "autolink", "--help"], id="nested-help"),
+        pytest.param(["gh", "-h"], id="gh-h"),
+        pytest.param(["gh", "api", "--help", "-f", "title=bug"], id="help-wins-over-data"),
+        pytest.param(["gh", "api", "-X", "DELETE", "--help"], id="help-wins-over-delete"),
+    ])
+    def test_gh_help(self, tokens):
+        assert _ct(tokens) == "git_safe"
 
 
 # --- Profiles (FD-032) ---


### PR DESCRIPTION
## Summary

- `gh api` was classified as `lang_exec`, but the context resolver tried to resolve `api` as a script path, causing all `gh api` calls to ASK with "script not found"
- Add `_classify_gh()` as a Phase 2 flag classifier that scans the full command for write-indicating flags regardless of position
- `gh api` is the only `gh` subcommand that needs this — all others (~130) are fully covered by Phase 3 prefix tables

## Motivation

When Claude Code uses `gh api repos/owner/repo/contributors --jq 'length'` for repository investigation, nah classifies it as `lang_exec`. The `lang_exec` context resolver then tries to find a script named `api` relative to the working directory, fails, and falls back to ASK — blocking every read-only API call with a confirmation prompt.

This is the same class of issue as git range refs being misinterpreted as paths, but the fix here is structural: `gh api` needs flag-aware classification because the same prefix can be read-only or destructive depending on flags.

## Changes

**`src/nah/taxonomy.py`** — Add `_classify_gh()` flag classifier (Phase 2) with supporting constants:

| Flags | Classification | Policy |
|-------|---------------|--------|
| None (bare `gh api endpoint`) | `git_safe` | allow |
| `-f`/`-F`/`--field`/`--raw-field`/`--input` (implicit POST) | `git_write` | allow |
| `-X POST`/`PUT`/`PATCH` | `git_write` | allow |
| `-X DELETE` | `git_history_rewrite` | ask |
| `-f` with `-X GET`/`HEAD` | `git_safe` | allow (query params) |
| `--help`/`-h` on any `gh` command | `git_safe` | allow |

Design decisions:
- DELETE → `git_history_rewrite` aligns with `gh repo delete`, `gh issue delete` in prefix tables
- `-f` with explicit `-X GET`/`HEAD` treated as query parameters, not a write (matches `gh api` documented behavior)
- `--help`/`-h` early return covers all `gh` subcommands (`-h` is help in gh, unlike curl where `-h` is `--header`)

**`src/nah/data/classify_full/lang_exec.json`** — Remove `gh api` (now handled by Phase 2)

**`tests/test_taxonomy.py`** — Add 44 parametrized test cases with pytest IDs covering all branches

## Testing

- All existing `TestGhCommands` prefix-table tests pass unchanged
- `test_all_classify_full_entries_roundtrip` passes
- Verified against 327 real `gh` commands extracted from production `nah.log`
- Edge cases: truncated `-X`, unknown methods, `-X HEAD` + `-f`, `--help` winning over write flags, `DELETE` + `-f` interaction