### PR TITLE
Store LLM API keys in OS keyring instead of env vars

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,10 @@ classifiers = [
     "Topic :: Software Development :: Quality Assurance",
 ]
 
+dependencies = [
+    "keyring>=25.0",
+]
+
 [project.optional-dependencies]
 dev = ["pytest"]
 config = ["pyyaml>=6.0"]
@@ -55,3 +59,7 @@ packages = ["src/nah"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+addopts = "-m 'not integration'"
+markers = [
+    "integration: tests that use the real OS keyring (run with: pytest -m integration)",
+]

--- a/src/nah/llm.py
+++ b/src/nah/llm.py
@@ -9,8 +9,54 @@ from dataclasses import dataclass, field
 from typing import NamedTuple
 from urllib.error import URLError
 
+import keyring
+
 _TIMEOUT_LOCAL = 10
 _TIMEOUT_REMOTE = 10
+
+_KEYRING_SERVICE = "nah"
+_migrated: set[str] = set()
+
+
+def _resolve_key(key_env: str) -> str:
+    """Resolve API key: keyring → env var (auto-migrate) → empty string.
+
+    When a key exists in env var but not in keyring, it is automatically
+    copied into the OS keyring and a one-time hint is printed to stderr
+    (visible to the user, not captured by the calling agent) suggesting
+    the user remove the env var.
+    """
+    # 1. Try keyring
+    try:
+        keyring_val = keyring.get_password(_KEYRING_SERVICE, key_env) or ""
+    except Exception as exc:
+        keyring_val = ""
+        sys.stderr.write(f"nah: keyring: read failed for {key_env}: {exc}\n")
+
+    if keyring_val:
+        return keyring_val
+
+    # 2. Fallback to env var
+    env_val = os.environ.get(key_env, "")
+    if not env_val:
+        return ""
+
+    # 3. Auto-migrate: copy env var → keyring, hint to remove env var
+    if key_env not in _migrated:
+        _migrated.add(key_env)
+        try:
+            keyring.set_password(_KEYRING_SERVICE, key_env, env_val)
+            sys.stderr.write(
+                f"nah: keyring: migrated {key_env} — "
+                f"you can now remove the env var\n"
+            )
+        except Exception:
+            sys.stderr.write(
+                f"nah: keyring: write failed for {key_env} — "
+                f"store with: python -m keyring set nah {key_env}\n"
+            )
+
+    return env_val
 
 
 class PromptParts(NamedTuple):
@@ -472,7 +518,7 @@ def _call_openai_compat(
     if not url:
         return None
     key_env = config.get("key_env", default_key_env)
-    key = os.environ.get(key_env, "")
+    key = _resolve_key(key_env)
     if not key:
         return None
     model = config.get("model", default_model)
@@ -515,7 +561,7 @@ def _call_cortex(
         )
 
     key_env = config.get("key_env", "SNOWFLAKE_PAT")
-    pat = os.environ.get(key_env, "")
+    pat = _resolve_key(key_env)
     if not pat:
         return None
 
@@ -566,7 +612,7 @@ def _call_openai_responses(
     if not url:
         return None
     key_env = config.get("key_env", default_key_env)
-    key = os.environ.get(key_env, "")
+    key = _resolve_key(key_env)
     if not key:
         return None
     model = config.get("model", default_model)
@@ -610,7 +656,7 @@ def _call_anthropic(
     """Call Anthropic Messages API."""
     url = config.get("url", "https://api.anthropic.com/v1/messages")
     key_env = config.get("key_env", "ANTHROPIC_API_KEY")
-    key = os.environ.get(key_env, "")
+    key = _resolve_key(key_env)
     if not key:
         return None
     model = config.get("model", "claude-haiku-4-5")

--- a/src/nah/setup_keys.py
+++ b/src/nah/setup_keys.py
@@ -1,0 +1,194 @@
+"""Interactive API key setup for nah LLM providers.
+
+Stores API keys in the OS keyring (Windows Credential Manager /
+macOS Keychain / Linux SecretService).
+
+Usage:
+  python -m nah.setup_keys           # Opens GUI window for secure key entry
+  python -m nah.setup_keys --status  # Check configured keys (no secrets shown)
+
+When called without --status, launches a tkinter GUI in a subprocess
+and blocks until the user closes it. Prints a JSON summary to stdout
+so the calling agent can confirm the result without seeing key values.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+try:
+    import keyring
+except ImportError:
+    print("Error: keyring not installed. Run: pip install keyring", file=sys.stderr)
+    sys.exit(1)
+
+_SERVICE = "nah"
+
+# (env_var_name, display_name, docs_url)
+_KEYS = [
+    ("ANTHROPIC_API_KEY", "Anthropic",
+     "https://console.anthropic.com/settings/keys"),
+    ("OPENAI_API_KEY", "OpenAI",
+     "https://platform.openai.com/api-keys"),
+    ("OPENROUTER_API_KEY", "OpenRouter",
+     "https://openrouter.ai/settings/keys"),
+    ("SNOWFLAKE_PAT", "Snowflake Cortex (PAT)",
+     "https://docs.snowflake.com/en/user-guide/programmatic-access-tokens"),
+]
+
+
+def get_status():
+    """Return current key configuration status."""
+    result = {}
+    for key_env, description, url in _KEYS:
+        result[key_env] = {
+            "description": description,
+            "configured": bool(keyring.get_password(_SERVICE, key_env)),
+        }
+    return result
+
+
+def gui_setup(marker_path=None):
+    """Open a tkinter GUI window for secure API key entry."""
+    import tkinter as tk
+    from tkinter import ttk
+    import webbrowser
+
+    root = tk.Tk()
+    root.title("nah — LLM API Key Setup")
+    root.resizable(False, False)
+
+    root.update_idletasks()
+    root.geometry("+200+100")
+
+    style = ttk.Style()
+    style.configure("Link.TLabel", foreground="#4a9eed")
+    style.configure("Status.TLabel", foreground="#888888", font=("", 8))
+    style.configure("Set.TLabel", foreground="#2ecc71", font=("", 8))
+
+    frame = ttk.Frame(root, padding=20)
+    frame.grid(sticky="nsew")
+
+    ttk.Label(frame, text="nah LLM API Key Setup",
+              font=("", 12, "bold")).grid(row=0, column=0, columnspan=3, pady=(0, 4))
+    ttk.Label(frame, text=f"keyring service: {_SERVICE}",
+              style="Status.TLabel").grid(row=1, column=0, columnspan=3, pady=(0, 4))
+    ttk.Label(frame, text="Only configure the provider(s) you use.",
+              style="Status.TLabel").grid(row=2, column=0, columnspan=3, pady=(0, 12))
+
+    ttk.Separator(frame, orient="horizontal").grid(
+        row=3, column=0, columnspan=3, sticky="ew", pady=(0, 8))
+
+    entries = {}
+    for i, (key_env, description, url) in enumerate(_KEYS):
+        row = i * 2 + 4
+        existing = keyring.get_password(_SERVICE, key_env)
+
+        desc_frame = ttk.Frame(frame)
+        desc_frame.grid(row=row, column=0, columnspan=2, sticky="w", pady=(6, 0))
+
+        ttk.Label(desc_frame, text=description, font=("", 9, "bold")).pack(side="left")
+        if existing:
+            ttk.Label(desc_frame, text=" (configured)", style="Set.TLabel").pack(side="left")
+
+        link = ttk.Label(desc_frame, text="  Get Key", style="Link.TLabel", cursor="hand2")
+        link.pack(side="left", padx=(8, 0))
+        link.bind("<Button-1>", lambda e, u=url: webbrowser.open(u))
+
+        entry_row = row + 1
+        entry = ttk.Entry(frame, width=60)
+        entry.grid(row=entry_row, column=0, columnspan=2, sticky="ew", padx=(0, 8))
+        if existing:
+            entry.insert(0, "(keep current)")
+
+            def on_focus_in(e, ent=entry):
+                if ent.get() == "(keep current)":
+                    ent.delete(0, "end")
+
+            def on_focus_out(e, ent=entry, ex=existing):
+                if not ent.get():
+                    ent.insert(0, "(keep current)")
+
+            entry.bind("<FocusIn>", on_focus_in)
+            entry.bind("<FocusOut>", on_focus_out)
+
+        entries[key_env] = entry
+
+    ttk.Separator(frame, orient="horizontal").grid(
+        row=len(_KEYS) * 2 + 4, column=0, columnspan=3, sticky="ew", pady=(12, 8))
+
+    status_var = tk.StringVar(value="Leave fields blank to keep current values.")
+    status_label = ttk.Label(frame, textvariable=status_var, style="Status.TLabel")
+    status_label.grid(row=len(_KEYS) * 2 + 5, column=0, columnspan=2, sticky="w")
+
+    def on_save():
+        changed = 0
+        for key_env, entry in entries.items():
+            value = entry.get().strip()
+            if value and value != "(keep current)":
+                keyring.set_password(_SERVICE, key_env, value)
+                changed += 1
+        if changed:
+            status_var.set(f"{changed} key(s) saved to OS keyring.")
+        else:
+            status_var.set("No changes made.")
+        save_btn.config(state="disabled")
+        root.after(2000, root.destroy)
+
+    btn_frame = ttk.Frame(frame)
+    btn_frame.grid(row=len(_KEYS) * 2 + 5, column=2, sticky="e")
+
+    save_btn = ttk.Button(btn_frame, text="Save", command=on_save)
+    save_btn.pack(side="right")
+
+    ttk.Button(btn_frame, text="Cancel", command=root.destroy).pack(side="right", padx=(0, 4))
+
+    root.mainloop()
+
+    if marker_path:
+        Path(marker_path).touch()
+
+
+def detached_setup():
+    """Launch GUI in a subprocess, block until done."""
+    script = str(Path(__file__).resolve())
+    fd, tmp = tempfile.mkstemp(suffix=".done", prefix="nah-keyring-")
+    os.close(fd)
+    marker = Path(tmp)
+    marker.unlink()  # mkstemp creates the file; remove it so we can use existence as signal
+
+    subprocess.Popen([sys.executable, script, "--_gui", str(marker)])
+
+    while not marker.exists():
+        time.sleep(0.5)
+    marker.unlink()
+
+    status = get_status()
+    configured = [k for k, v in status.items() if v["configured"]]
+    print(json.dumps({
+        "configured": len(configured),
+        "total": len(_KEYS),
+        "keys": configured,
+    }))
+
+
+def main():
+    if "--_gui" in sys.argv:
+        idx = sys.argv.index("--_gui")
+        marker = sys.argv[idx + 1] if len(sys.argv) > idx + 1 else None
+        gui_setup(marker)
+    elif "--status" in sys.argv:
+        status = get_status()
+        for key_env, info in status.items():
+            mark = "+" if info["configured"] else "-"
+            print(f"  [{mark}] {info['description']} ({key_env})")
+    else:
+        detached_setup()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Shared fixtures for nah tests."""
 
 import os
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -39,6 +40,33 @@ def _reset_state():
     content._content_patterns_merged = True
     reset_config()
     hook._transcript_path = ""
+
+
+@pytest.fixture(autouse=True)
+def _mock_keyring(request):
+    """Isolate tests from the real OS keyring.
+
+    All tests get a keyring that returns None by default.
+    Tests marked with @pytest.mark.integration skip this mock
+    and use the real OS keyring.
+    """
+    if request.node.get_closest_marker("integration"):
+        yield MagicMock()  # yield a dummy (unused) to keep fixture signature
+        return
+    mock_kr = MagicMock()
+    mock_kr.get_password.return_value = None
+    mock_kr.set_password.return_value = None
+    with patch("nah.llm.keyring", mock_kr):
+        yield mock_kr
+
+
+@pytest.fixture(autouse=True)
+def _reset_migrated():
+    """Clear the keyring auto-migration dedup set between tests."""
+    from nah.llm import _migrated
+    _migrated.clear()
+    yield
+    _migrated.clear()
 
 
 @pytest.fixture

--- a/tests/test_keyring.py
+++ b/tests/test_keyring.py
@@ -1,0 +1,190 @@
+"""Tests for keyring integration in the LLM layer."""
+
+import os
+from unittest.mock import patch
+
+import keyring as real_keyring
+import pytest
+
+from nah.llm import _resolve_key, _KEYRING_SERVICE
+
+
+class TestResolveKey:
+    """Tests for _resolve_key(): keyring → env var (auto-migrate) → empty."""
+
+    def test_keyring_value_preferred(self, _mock_keyring):
+        """When keyring has a value, use it regardless of env var."""
+        _mock_keyring.get_password.return_value = "kr-secret"
+        with patch.dict(os.environ, {"TEST_KEY": "env-secret"}):
+            result = _resolve_key("TEST_KEY")
+        assert result == "kr-secret"
+        _mock_keyring.set_password.assert_not_called()
+
+    def test_env_fallback_when_keyring_empty(self, _mock_keyring):
+        """When keyring returns None, fall back to env var."""
+        with patch.dict(os.environ, {"TEST_KEY": "env-secret"}):
+            result = _resolve_key("TEST_KEY")
+        assert result == "env-secret"
+
+    def test_empty_when_neither(self, _mock_keyring):
+        """When neither keyring nor env var has a value, return empty."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("NONEXISTENT_KEY", None)
+            result = _resolve_key("NONEXISTENT_KEY")
+        assert result == ""
+        _mock_keyring.set_password.assert_not_called()
+
+    def test_keyring_returns_empty_string(self, _mock_keyring):
+        """When keyring returns empty string, treat as absent and fallback."""
+        _mock_keyring.get_password.return_value = ""
+        with patch.dict(os.environ, {"TEST_KEY": "env-secret"}):
+            result = _resolve_key("TEST_KEY")
+        assert result == "env-secret"
+
+    def test_env_var_empty_string_treated_as_absent(self, _mock_keyring):
+        """When env var is explicitly set to empty string, treat as absent."""
+        with patch.dict(os.environ, {"TEST_KEY": ""}):
+            result = _resolve_key("TEST_KEY")
+        assert result == ""
+        _mock_keyring.set_password.assert_not_called()
+
+    def test_keyring_read_error_falls_back_with_stderr(self, _mock_keyring, capsys):
+        """When keyring.get_password raises, fall back to env var and warn."""
+        _mock_keyring.get_password.side_effect = RuntimeError("backend error")
+        with patch.dict(os.environ, {"TEST_KEY": "env-fallback"}):
+            result = _resolve_key("TEST_KEY")
+        assert result == "env-fallback"
+        captured = capsys.readouterr()
+        assert "nah: keyring: read failed" in captured.err
+        assert "backend error" in captured.err
+
+    def test_auto_migrate_env_to_keyring(self, _mock_keyring):
+        """When key is in env but not keyring, auto-migrate to keyring."""
+        with patch.dict(os.environ, {"MY_API_KEY": "secret-val"}):
+            _resolve_key("MY_API_KEY")
+        _mock_keyring.set_password.assert_called_once_with(
+            _KEYRING_SERVICE, "MY_API_KEY", "secret-val",
+        )
+
+    def test_auto_migrate_message_on_stderr(self, _mock_keyring, capsys):
+        """Auto-migration prints a message to stderr."""
+        with patch.dict(os.environ, {"MY_API_KEY": "secret"}):
+            _resolve_key("MY_API_KEY")
+        captured = capsys.readouterr()
+        assert "nah: keyring: migrated" in captured.err
+        assert "remove the env var" in captured.err
+
+    def test_auto_migrate_only_once(self, _mock_keyring):
+        """Auto-migration happens only once per key_env per process."""
+        with patch.dict(os.environ, {"MY_API_KEY": "secret"}):
+            _resolve_key("MY_API_KEY")
+            _resolve_key("MY_API_KEY")
+        assert _mock_keyring.set_password.call_count == 1
+
+    def test_auto_migrate_fallback_when_write_fails(self, _mock_keyring, capsys):
+        """When keyring write fails, still return env value and show hint."""
+        _mock_keyring.set_password.side_effect = RuntimeError("write failed")
+        with patch.dict(os.environ, {"MY_API_KEY": "secret"}):
+            result = _resolve_key("MY_API_KEY")
+        assert result == "secret"
+        captured = capsys.readouterr()
+        assert "nah: keyring: write failed" in captured.err
+
+    def test_no_migrate_when_keyring_has_value(self, _mock_keyring):
+        """No migration when keyring already has the key."""
+        _mock_keyring.get_password.return_value = "kr-secret"
+        with patch.dict(os.environ, {"MY_API_KEY": "env-secret"}):
+            _resolve_key("MY_API_KEY")
+        _mock_keyring.set_password.assert_not_called()
+
+    def test_no_migrate_when_env_empty(self, _mock_keyring):
+        """No migration when env var is not set."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MY_API_KEY", None)
+            _resolve_key("MY_API_KEY")
+        _mock_keyring.set_password.assert_not_called()
+
+
+# -- Integration tests (real OS keyring) --
+# Run with: pytest -m integration
+
+
+_TEST_KEY = "NAH_TEST_INTEGRATION_KEY"
+_TEST_MIGRATE_KEY = "NAH_TEST_MIGRATE_KEY"
+
+
+def _cleanup(*keys: str) -> None:
+    """Delete test keys from real keyring, ignoring errors."""
+    for k in keys:
+        try:
+            real_keyring.delete_password(_KEYRING_SERVICE, k)
+        except Exception:
+            pass
+
+
+@pytest.mark.integration
+class TestKeyringIntegration:
+    """Real OS keyring round-trip tests. Requires keyring backend."""
+
+    def test_roundtrip(self):
+        """set → _resolve_key → delete."""
+        _cleanup(_TEST_KEY)
+        try:
+            real_keyring.set_password(_KEYRING_SERVICE, _TEST_KEY, "int-test-val")
+            result = _resolve_key(_TEST_KEY)
+            assert result == "int-test-val"
+        finally:
+            _cleanup(_TEST_KEY)
+
+    def test_auto_migrate_real(self, capsys):
+        """env var → auto-migrate → verify in real keyring."""
+        _cleanup(_TEST_MIGRATE_KEY)
+        try:
+            with patch.dict(os.environ, {_TEST_MIGRATE_KEY: "env-migrate-val"}):
+                result = _resolve_key(_TEST_MIGRATE_KEY)
+            assert result == "env-migrate-val"
+
+            # verify actually written to real keyring
+            kr_val = real_keyring.get_password(_KEYRING_SERVICE, _TEST_MIGRATE_KEY)
+            assert kr_val == "env-migrate-val"
+
+            captured = capsys.readouterr()
+            assert "migrated" in captured.err
+        finally:
+            _cleanup(_TEST_MIGRATE_KEY)
+
+    def test_full_migration_lifecycle(self):
+        """Full migration: env var → auto-migrate → remove env → keyring-only."""
+        _cleanup(_TEST_MIGRATE_KEY)
+        try:
+            # 1. Start with env var only
+            from nah.llm import _migrated
+            _migrated.discard(_TEST_MIGRATE_KEY)
+
+            with patch.dict(os.environ, {_TEST_MIGRATE_KEY: "migrate-me"}):
+                result = _resolve_key(_TEST_MIGRATE_KEY)
+            assert result == "migrate-me"
+
+            # 2. Verify migrated to keyring
+            kr_val = real_keyring.get_password(_KEYRING_SERVICE, _TEST_MIGRATE_KEY)
+            assert kr_val == "migrate-me"
+
+            # 3. Remove env var — next call should read from keyring only
+            _migrated.discard(_TEST_MIGRATE_KEY)
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop(_TEST_MIGRATE_KEY, None)
+                result = _resolve_key(_TEST_MIGRATE_KEY)
+            assert result == "migrate-me"
+        finally:
+            _cleanup(_TEST_MIGRATE_KEY)
+
+    def test_keyring_preferred_over_env(self):
+        """When both keyring and env have values, keyring wins."""
+        _cleanup(_TEST_KEY)
+        try:
+            real_keyring.set_password(_KEYRING_SERVICE, _TEST_KEY, "from-keyring")
+            with patch.dict(os.environ, {_TEST_KEY: "from-env"}):
+                result = _resolve_key(_TEST_KEY)
+            assert result == "from-keyring"
+        finally:
+            _cleanup(_TEST_KEY)


### PR DESCRIPTION
## Summary

- Add `_resolve_key()` to read LLM API keys from OS keyring with env var fallback
- Auto-migrate existing env var keys into keyring on first use
- Add `nah.setup_keys` module — interactive GUI for secure API key entry (`python -m nah.setup_keys`)
- Add `keyring>=25.0` as dependency
- 12 unit tests + 4 integration tests (`pytest -m integration`)

## Motivation

When nah's LLM feature is enabled, API keys are read from environment
variables. In the Claude Code context, all child processes (Bash tool,
MCP servers, hooks) inherit the parent's env vars by default. A prompt
injection attack that tricks the agent into running `printenv` or
`echo $ANTHROPIC_API_KEY` can exfiltrate the key.

Claude Code offers `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` to strip known
provider keys, but its hardcoded allowlist only covers `ANTHROPIC_API_KEY`
among nah's supported providers — `OPENAI_API_KEY`, `OPENROUTER_API_KEY`,
`SNOWFLAKE_PAT`, and any custom `key_env` are not protected.

OS keyring values are not in the process environment block, so they
cannot be leaked through child process inheritance.

## Changes

### `_resolve_key(key_env)` — keyring read with env fallback

Replaces `os.environ.get(key_env, "")` in all 4 provider functions.
Resolution order:

1. **OS keyring** (`keyring.get_password("nah", key_env)`) — DPAPI on
   Windows, Keychain on macOS, SecretService on Linux
2. **Env var fallback** — existing setups continue to work unchanged
3. **Auto-migrate** — when a key exists only in env var, it is copied to
   keyring with a stderr hint to remove the env var

All stderr messages use the `nah: keyring:` prefix and are visible to the
user but **not captured by the calling agent** (stderr is not part of hook
JSON output).

### `nah.setup_keys` module — interactive GUI setup

<img width="978" height="586" alt="image" src="https://github.com/user-attachments/assets/aefb82c5-da34-4615-8dd6-41ef9dcf1272" />

A tkinter-based GUI for secure API key entry. Keys are entered in a
separate window (plaintext for easy verification) and written directly to
the OS keyring — they never appear in the terminal, agent context, or logs.

```
python -m nah.setup_keys           # Opens GUI, blocks until done, prints JSON summary
python -m nah.setup_keys --status  # Check which keys are configured (no secrets shown)
```

The script launches the GUI in a subprocess and blocks until the user
closes it, then prints a machine-readable JSON summary to stdout:

```json
{"configured": 2, "total": 4, "keys": ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"]}
```

This allows an AI agent to invoke the script, wait for completion, and
confirm the result — without ever seeing the key values.

### Backward compatibility

- Existing env var configurations work unchanged
- If keyring read fails (broken backend), falls back to env var with stderr warning
- Core structural classification is unaffected (`hook.py` lazy-imports
  `llm.py` with `except ImportError`)

### User setup (new installs)

GUI method (recommended):
```
python -m nah.setup_keys
```

CLI method:
```
python -m keyring set nah ANTHROPIC_API_KEY
```

## Discussion points

- **Hard vs optional dependency**: This PR adds `keyring` as a hard dependency.
  I'm aware of the "zero external dependencies for the core hook" principle —
  keyring only affects the LLM layer (already optional via lazy import), not the
  structural classifier. Happy to move it to `[project.optional-dependencies]`
  if preferred.
- **Windows/macOS**: keyring uses built-in OS backends (zero additional deps).
  Linux pulls `secretstorage` + `jeepney` via pip.
- **Plugin integration**: see #64 — if nah adopts plugin distribution,
  `_resolve_key()` and `setup_keys.py` provide the foundation for a
  `/nah:setup` slash command.

## Testing

- [x] 12 unit tests covering all `_resolve_key()` paths (priority, fallback,
  auto-migrate, dedup, error handling, empty string edge cases)
- [x] 4 integration tests against real OS keyring (`pytest -m integration`),
  including full migration lifecycle (env → migrate → remove env → keyring-only)
- [x] conftest fixtures isolate all existing tests from real keyring
- [x] Existing LLM tests pass with zero regression
- [x] `setup_keys.py` manually tested on Windows (GUI opens, saves to keyring,
  returns JSON summary)
