### PR TITLE
feat: strip kubectl global flags before subcommand classification

### DIFF
--- a/src/nah/taxonomy.py
+++ b/src/nah/taxonomy.py
@@ -354,6 +354,15 @@ def classify_tokens(
             if result != UNKNOWN:
                 return result
 
+    # kubectl: strip global flags (e.g. -n ns, --context=ctx) before matching.
+    # Without this, `kubectl -n namespace logs pod` fails to match `kubectl logs`.
+    if tokens[0] == "kubectl":
+        tokens = _strip_kubectl_global_flags(tokens)
+        if global_table:
+            result = _prefix_match(tokens, global_table)
+            if result != UNKNOWN:
+                return result
+
     # --- Phase 2: Flag classifiers (built-in opinions) ---
     # Skipped entirely when profile == "none".
     if profile != "none":
@@ -471,6 +480,82 @@ def _git_has_short_flag(args: list[str], flag: str) -> bool:
         if arg.startswith("-") and not arg.startswith("--") and flag in arg[1:]:
             return True
     return False
+
+
+# kubectl global flags that take a value argument and appear before the subcommand.
+_KUBECTL_VALUE_FLAGS = {
+    "-n", "--namespace",
+    "--context",
+    "--kubeconfig",
+    "--cluster",
+    "--user",
+    "-s", "--server",
+    "--token",
+    "--as",
+    "--as-group",
+    "--as-uid",
+    "--certificate-authority",
+    "--client-certificate",
+    "--client-key",
+    "--cache-dir",
+    "--request-timeout",
+    "--tls-server-name",
+}
+
+# kubectl global boolean flags (no value argument).
+_KUBECTL_BOOLEAN_FLAGS = {
+    "--insecure-skip-tls-verify",
+    "--warnings-as-errors",
+}
+
+# kubectl global flags in --flag=value form (prefix match).
+_KUBECTL_VALUE_FLAG_PREFIXES = (
+    "--namespace=",
+    "--context=",
+    "--kubeconfig=",
+    "--cluster=",
+    "--user=",
+    "--server=",
+    "--token=",
+    "--as=",
+    "--as-group=",
+    "--as-uid=",
+    "--certificate-authority=",
+    "--client-certificate=",
+    "--client-key=",
+    "--cache-dir=",
+    "--request-timeout=",
+    "--tls-server-name=",
+)
+
+
+def _strip_kubectl_global_flags(tokens: list[str]) -> list[str]:
+    """Strip kubectl global flags (e.g. -n ns, --context=ctx) from token list.
+
+    Preserves 'kubectl' as first token followed by the subcommand and its args.
+    Malformed value-taking flags stop stripping so classification fails closed.
+    """
+    result = [tokens[0]]  # keep "kubectl"
+    i = 1
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok in _KUBECTL_VALUE_FLAGS:
+            if i + 1 >= len(tokens):
+                # Flag without value — fail closed.
+                result.extend(tokens[i:])
+                break
+            i += 2  # skip flag + its value
+        elif any(tok.startswith(prefix) for prefix in _KUBECTL_VALUE_FLAG_PREFIXES):
+            i += 1  # skip =joined value flag
+        elif tok in _KUBECTL_BOOLEAN_FLAGS:
+            i += 1  # skip boolean flag
+        elif tok.startswith("-v=") or (len(tok) > 2 and tok.startswith("-v") and tok[2:].isdigit()):
+            i += 1  # skip verbosity flag (-v=3, -v3)
+        else:
+            # Reached the subcommand — append rest as-is.
+            result.extend(tokens[i:])
+            break
+    return result
 
 
 def _strip_git_global_flags(tokens: list[str]) -> list[str]:

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -486,6 +486,83 @@ class TestClassifyTokens:
     def test_basename_normalization(self):
         assert _ct(["/usr/bin/rm", "-rf", "/"]) == "filesystem_delete"
 
+    # kubectl global flag stripping
+    # kubectl is not in the builtin table — it's user-config only.
+    # Tests use global_table to mirror the real code path.
+
+    def _kubectl_table(self):
+        """Minimal kubectl global_table matching the typical user config."""
+        return build_user_table({
+            "filesystem_read": ["kubectl logs", "kubectl get", "kubectl describe"],
+            "network_write": ["kubectl apply", "kubectl create", "kubectl patch"],
+            "lang_exec": ["kubectl exec"],
+        })
+
+    def test_kubectl_n_flag_stripped(self):
+        tbl = self._kubectl_table()
+        assert classify_tokens(
+            ["kubectl", "-n", "mynamespace", "logs", "pod"],
+            global_table=tbl, builtin_table=_FULL,
+        ) == "filesystem_read"
+
+    def test_kubectl_namespace_long_flag_stripped(self):
+        tbl = self._kubectl_table()
+        assert classify_tokens(
+            ["kubectl", "--namespace", "mynamespace", "logs", "pod"],
+            global_table=tbl, builtin_table=_FULL,
+        ) == "filesystem_read"
+
+    def test_kubectl_namespace_equals_joined_stripped(self):
+        tbl = self._kubectl_table()
+        assert classify_tokens(
+            ["kubectl", "--namespace=mynamespace", "logs", "pod"],
+            global_table=tbl, builtin_table=_FULL,
+        ) == "filesystem_read"
+
+    def test_kubectl_context_flag_stripped(self):
+        tbl = self._kubectl_table()
+        assert classify_tokens(
+            ["kubectl", "--context=prod", "get", "pods"],
+            global_table=tbl, builtin_table=_FULL,
+        ) == "filesystem_read"
+
+    def test_kubectl_multiple_global_flags_stripped(self):
+        tbl = self._kubectl_table()
+        assert classify_tokens(
+            ["kubectl", "--context=prod", "-n", "kube-system", "get", "pods"],
+            global_table=tbl, builtin_table=_FULL,
+        ) == "filesystem_read"
+
+    def test_kubectl_n_before_apply_still_network_write(self):
+        tbl = self._kubectl_table()
+        assert classify_tokens(
+            ["kubectl", "-n", "mynamespace", "apply", "-f", "deploy.yaml"],
+            global_table=tbl, builtin_table=_FULL,
+        ) == "network_write"
+
+    def test_kubectl_n_before_exec_still_lang_exec(self):
+        tbl = self._kubectl_table()
+        assert classify_tokens(
+            ["kubectl", "-n", "mynamespace", "exec", "-it", "pod", "--", "bash"],
+            global_table=tbl, builtin_table=_FULL,
+        ) == "lang_exec"
+
+    def test_kubectl_global_flags_work_with_global_overrides(self):
+        tbl = build_user_table({"testing": ["kubectl logs"]})
+        assert classify_tokens(
+            ["kubectl", "-n", "mynamespace", "logs", "pod"],
+            global_table=tbl,
+            builtin_table=_FULL,
+        ) == "testing"
+
+    def test_kubectl_n_flag_missing_value_fails_closed(self):
+        # -n without value — fail closed (no subcommand to classify)
+        tbl = self._kubectl_table()
+        assert classify_tokens(
+            ["kubectl", "-n"],
+            global_table=tbl, builtin_table=_FULL,
+        ) == "unknown"
+
     def test_basename_curl(self):
         assert _ct(["/usr/local/bin/curl", "-X", "POST", "url"]) == "network_write"
 


### PR DESCRIPTION
## Summary

kubectl supports global flags (`-n`, `--namespace`, `--context`, `--kubeconfig`, etc.) that appear **before** the subcommand. Without stripping these, a command like:

```
kubectl -n mynamespace logs pod
```

fails to match the `kubectl logs` prefix and falls through to `unknown → ask`, even when the user has `kubectl logs` classified as `filesystem_read`.

## Root cause

`classify_tokens()` already handles this for `git` via `_strip_git_global_flags()`. kubectl has the same pattern but no equivalent stripping.

## Changes

- **`src/nah/taxonomy.py`**: Add `_strip_kubectl_global_flags()` modelled on `_strip_git_global_flags()`, covering all kubectl global flags that take a value (`-n ns`, `--context=ctx`, `--kubeconfig=path`, `--cluster`, `--user`, `--server`, `--token`, `--as`, `--as-group`, `--as-uid`, `--certificate-authority`, `--client-certificate`, `--client-key`, `--cache-dir`, `--request-timeout`, `--tls-server-name`) and boolean flags (`--insecure-skip-tls-verify`, `--warnings-as-errors`). Called in `classify_tokens()` after the Phase 1 global-table check for kubectl.

- **`tests/test_taxonomy.py`**: 9 new tests covering `-n`, `--namespace`, `--namespace=`, `--context=`, multiple flags, write/exec classification preserved, global_table override, and missing-value fail-closed behaviour.

## Behaviour

After this change, `kubectl -n ns logs pod` classifies identically to `kubectl logs pod` against the user's global table. Classification of write (`kubectl apply`) and exec (`kubectl exec`) subcommands is preserved correctly.

Closes #67
