### PR TITLE
fix: recognize Windows drive-letter paths in nah trust

### DIFF
--- a/src/nah/cli.py
+++ b/src/nah/cli.py
@@ -592,7 +592,7 @@ def cmd_classify(args: argparse.Namespace) -> None:
 def cmd_trust(args: argparse.Namespace) -> None:
     """Trust a path or network host (global config only)."""
     target = args.target
-    is_path = target.startswith(("/", "~", "."))
+    is_path = target.startswith(("/", "~", ".")) or (len(target) >= 2 and target[1] == ":")
 
     if is_path and getattr(args, "project", False):
         print("trusted_paths is global-only — cannot use --project", file=sys.stderr)


### PR DESCRIPTION
## Summary

- `nah trust C:/Projects` on Windows silently writes to `known_registries` (network hosts) instead of `trusted_paths`, because `is_path` only checks for `/`, `~`, `.` prefixes
- This causes `check_project_boundary` to keep flagging cross-project edits as "outside project" even after the user trusts the parent directory
- Add a check for drive-letter syntax (`X:`) so Windows absolute paths route correctly to `write_trust_path`

## Repro

On Windows:
```
nah trust C:/Projects
nah config show   # C:/Projects appears under known_registries, not trusted_paths
nah test --tool Edit --path "C:/Projects/OtherRepo/file.py" "test"  # still ASK
```

## Test plan

- [ ] `nah trust C:/Projects` writes to `trusted_paths` (not `known_registries`)
- [ ] `nah trust D:/work` also recognized as a path
- [ ] Unix-style paths (`/tmp`, `~/.config`, `./local`) still work as before
- [ ] Network hosts (`api.example.com`) still route to `known_registries`

🤖 Generated with [Claude Code](https://claude.com/claude-code)