### PR TITLE
fix: resolve direct script execution path for non-interpreter commands

### DIFF
--- a/src/nah/bash.py
+++ b/src/nah/bash.py
@@ -1796,8 +1796,25 @@ def _resolve_script_path(tokens: list[str]) -> str | None:
 
     cmd = os.path.basename(tokens[0])
 
-    from nah.taxonomy import _INLINE_FLAGS, _MODULE_FLAGS, _VALUE_FLAGS, _normalize_interpreter
+    from nah.taxonomy import (
+        _INLINE_FLAGS,
+        _MODULE_FLAGS,
+        _SCRIPT_INTERPRETERS,
+        _VALUE_FLAGS,
+        _normalize_interpreter,
+    )
     cmd = _normalize_interpreter(cmd)
+
+    # Direct script execution (./script.sh, /abs/path/script.py, script.sh):
+    # tokens[0] IS the script, and tokens[1:] are its positional arguments.
+    # Without this branch, the loop below would treat the first non-flag
+    # argument as the script path, producing false-positive "script not found"
+    # asks for commands like `./bin/release.sh 2.0.0 prerelease` (issue #70).
+    if cmd not in _SCRIPT_INTERPRETERS:
+        raw = tokens[0]
+        if os.path.isabs(raw):
+            return raw
+        return os.path.realpath(raw) if os.path.isfile(raw) else os.path.join(os.getcwd(), raw)
 
     inline = _INLINE_FLAGS.get(cmd, set())
     module = _MODULE_FLAGS.get(cmd, set())
@@ -1823,10 +1840,6 @@ def _resolve_script_path(tokens: list[str]) -> str | None:
             return tok
         cwd = os.getcwd()
         return os.path.join(cwd, tok)
-
-    # ./script.py — tokens[0] is the script itself (direct execution)
-    if cmd != tokens[0]:
-        return os.path.realpath(tokens[0]) if os.path.isfile(tokens[0]) else tokens[0]
 
     return None
 

--- a/tests/test_fd079_script_exec.py
+++ b/tests/test_fd079_script_exec.py
@@ -291,6 +291,58 @@ class TestScriptPathResolution:
         result = _resolve_script_path(["python", "-v"])
         assert result is None
 
+    # --- Direct script execution (issue #70) -----------------------------
+    # When tokens[0] is not an interpreter, it IS the script, and tokens[1:]
+    # are its positional arguments. Earlier behaviour misread the first arg
+    # as the script path, producing "script not found" asks for commands
+    # like `./bin/release.sh 2.0.0 prerelease`.
+
+    def test_direct_script_absolute_no_args(self, project_root):
+        path = os.path.join(project_root, "bin", "release.sh")
+        _write(path, "#!/bin/bash\necho ok\n")
+        result = _resolve_script_path([path])
+        assert result == path
+
+    def test_direct_script_absolute_with_args(self, project_root):
+        path = os.path.join(project_root, "bin", "release.sh")
+        _write(path, "#!/bin/bash\necho \"$@\"\n")
+        result = _resolve_script_path([path, "2.0.0", "prerelease"])
+        assert result == path, "tokens[0] is the script; args must not be treated as the path"
+
+    def test_direct_script_relative_with_args_issue_70(self, project_root):
+        """Exact repro of issue #70: ./bin/script.sh 2.0.0 prerelease."""
+        os.makedirs(os.path.join(project_root, "bin"), exist_ok=True)
+        script = os.path.join(project_root, "bin", "resolve-release-version.sh")
+        _write(script, "#!/bin/bash\necho \"$1\"\n")
+        old_cwd = os.getcwd()
+        os.chdir(project_root)
+        try:
+            result = _resolve_script_path(["./bin/resolve-release-version.sh", "2.0.0", "prerelease"])
+            assert result is not None
+            assert result.endswith("bin/resolve-release-version.sh"), (
+                f"expected path ending in bin/resolve-release-version.sh, got {result!r}"
+            )
+            assert "2.0.0" not in result, "positional arg must not be treated as the script path"
+        finally:
+            os.chdir(old_cwd)
+
+    def test_direct_script_bare_relative_name(self, project_root):
+        """Bare relative name like `script.sh arg` resolves via cwd, not arg."""
+        old_cwd = os.getcwd()
+        os.chdir(project_root)
+        try:
+            result = _resolve_script_path(["script.sh", "arg1"])
+            assert result is not None
+            assert result.endswith("script.sh")
+            assert "arg1" not in result
+        finally:
+            os.chdir(old_cwd)
+
+    def test_direct_script_nonexistent_returns_script_path(self):
+        """Nonexistent direct script still returns script path, not the first arg."""
+        result = _resolve_script_path(["/var/empty/nonexistent.sh", "some-arg"])
+        assert result == "/var/empty/nonexistent.sh"
+
 
 # ===================================================================
 # 4. FULL PIPELINE INTEGRATION (classify_command)
@@ -367,6 +419,41 @@ class TestPipelineIntegration:
             assert r.final_decision == "allow"
             assert r.stages[0].action_type == "lang_exec"
             assert "script clean:" in r.stages[0].reason
+        finally:
+            os.chdir(old_cwd)
+
+    def test_direct_script_with_args_allowed_issue_70(self, project_root):
+        """Issue #70: direct script invocation with positional args must not be
+        misclassified as 'script not found: <arg>'."""
+        os.makedirs(os.path.join(project_root, "bin"), exist_ok=True)
+        script = os.path.join(project_root, "bin", "release.sh")
+        _write(script, "#!/bin/bash\necho \"$1\"\n")
+        old_cwd = os.getcwd()
+        os.chdir(project_root)
+        try:
+            r = classify_command("./bin/release.sh 2.0.0 prerelease")
+            assert r.final_decision == "allow", (
+                f"expected allow (script clean) but got {r.final_decision!r}: {r.reason!r}"
+            )
+            assert r.stages[0].action_type == "lang_exec"
+            assert "script clean:" in r.stages[0].reason
+            # The resolved path must name the script, not the positional arg.
+            assert "release.sh" in r.stages[0].reason
+            assert "2.0.0" not in r.stages[0].reason
+        finally:
+            os.chdir(old_cwd)
+
+    def test_direct_script_missing_names_script_not_arg(self, project_root):
+        """Missing direct script: 'script not found' reason must name the script,
+        not a positional argument (fail-closed behaviour preserved)."""
+        old_cwd = os.getcwd()
+        os.chdir(project_root)
+        try:
+            r = classify_command("./bin/does-not-exist.sh 2.0.0 prerelease")
+            assert r.final_decision == "ask"
+            assert "script not found" in r.reason
+            assert "does-not-exist.sh" in r.reason
+            assert "2.0.0" not in r.reason
         finally:
             os.chdir(old_cwd)
 


### PR DESCRIPTION
## Summary

Fixes #70. Direct script invocations with positional arguments (e.g.
`./bin/release.sh 2.0.0 prerelease`) were misclassified because
`_resolve_script_path()` in `src/nah/bash.py` scanned `tokens[1:]`
looking for the script file even when `tokens[0]` was itself the
script. The first non-flag positional argument (`2.0.0`) was returned
as the script path; downstream `resolve_lang_exec_context()` then
emitted `"script not found: <project>/2.0.0"` → `ask`.

The intended direct-script fallback after the loop
(`if cmd != tokens[0]`) was unreachable because the loop returned on
the first non-flag token.

## Root cause

When a command is invoked directly (`./script.sh`, `/abs/path/script.py`,
bare `script.sh`), the normalized command name is not in
`taxonomy._SCRIPT_INTERPRETERS`, so `_INLINE_FLAGS` / `_MODULE_FLAGS` /
`_VALUE_FLAGS` all return empty sets. The argument-scanning loop then
treats the first positional argument as the script file.

## Fix

When the normalized command is not in `_SCRIPT_INTERPRETERS`,
`tokens[0]` **is** the script — return it directly without scanning
args. The unreachable post-loop fallback is removed.

## Before / after

Against `./bin/release.sh 2.0.0 prerelease` with the script present in
a git project:

- **Before:** `ask` — `"script not found: <project>/2.0.0"`
- **After:** `allow` — `"script clean: <project>/bin/release.sh"`

For a missing direct script, the `"script not found"` reason now
names the script itself rather than a positional argument (fail-closed
behaviour preserved).

## Tests

Seven new tests in `tests/test_fd079_script_exec.py`:

- `test_direct_script_absolute_no_args` — absolute path, zero args.
- `test_direct_script_absolute_with_args` — absolute path with args,
  asserts `tokens[0]` wins.
- `test_direct_script_relative_with_args_issue_70` — exact repro of
  the issue.
- `test_direct_script_bare_relative_name` — `script.sh arg` resolves
  via `cwd`, not `arg`.
- `test_direct_script_nonexistent_returns_script_path` — missing
  script still yields the script path, not the first arg.
- `test_direct_script_with_args_allowed_issue_70` — end-to-end
  `classify_command` → `allow (script clean: ...release.sh)`.
- `test_direct_script_missing_names_script_not_arg` — end-to-end
  missing script → `ask` with reason naming the script.

`pytest tests/test_fd079_script_exec.py` passes (104/104). Full
`pytest` delta vs. `main`: +7 passing, no new failures.

Closes #70