### PR TITLE
packaging: add nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ site/
 
 # Beads / Dolt files (added by bd init)
 .beads-credential-key
+
+# nix default build output dir
+result/

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  python3,
+}:
+let
+  project = builtins.fromTOML (builtins.readFile ./pyproject.toml);
+  projectMeta = project.project;
+in
+
+python3.pkgs.buildPythonApplication {
+  pname = projectMeta.name;
+  version = projectMeta.version;
+  pyproject = true;
+
+  src = ./.;
+
+  build-system = [
+    python3.pkgs.hatchling
+  ];
+
+  optional-dependencies = with python3.pkgs; {
+    config = [
+      pyyaml
+    ];
+    dev = [
+      pytest
+    ];
+    docs = [
+      mkdocs-material
+    ];
+    keys = [
+      keyring
+    ];
+  };
+
+  pythonImportsCheck = [
+    "nah"
+  ];
+
+  meta = {
+    description = projectMeta.description;
+    homepage = "https://github.com/manuelschipper/nah";
+    changelog = "https://github.com/manuelschipper/nah/blob/main/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+    mainProgram = "nah";
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,56 @@
+{
+  description = "nah";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [
+        "aarch64-darwin"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+      mkOutputs = system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          nah = pkgs.callPackage ./default.nix {};
+        in
+        {
+          packages = {
+            default = nah;
+            nah = nah;
+          };
+          apps = {
+            default = {
+              type = "app";
+              program = "${nah}/bin/nah";
+            };
+          };
+          checks = {
+            default = nah;
+          };
+          devShells.default = pkgs.mkShell {
+            packages = [ nah ];
+          };
+        };
+    in
+    {
+      packages = builtins.listToAttrs (map (system: {
+        name = system;
+        value = (mkOutputs system).packages;
+      }) systems);
+      apps = builtins.listToAttrs (map (system: {
+        name = system;
+        value = (mkOutputs system).apps;
+      }) systems);
+      checks = builtins.listToAttrs (map (system: {
+        name = system;
+        value = (mkOutputs system).checks;
+      }) systems);
+      devShells = builtins.listToAttrs (map (system: {
+        name = system;
+        value = (mkOutputs system).devShells;
+      }) systems);
+    };
+}


### PR DESCRIPTION
## Summary

Pip global installs can get quite messy. This pull request introduces Nix and Nix Flake support for the project, enabling reproducible builds and development environments across multiple platforms. The main changes are the addition of `default.nix` and `flake.nix` files, which define how the Python application is built and packaged using Nix.

With `nix profile install github:manuelschipper/nah` users can get an immutable, rollbackable version of the binary, that won't interfere with any other python/pip setups.

## Test plan

None of the python files have been modified, but verified that `nix build` / `nix run . -- test "blah"`

---

By submitting this pull request, I confirm that I have read and agree to the [Contributor License Agreement](../CLA.md).
