### PR TITLE
feat: strip talosctl global flags before subcommand classification

### DIFF
--- a/src/nah/taxonomy.py
+++ b/src/nah/taxonomy.py
@@ -533,6 +533,16 @@ def classify_tokens(
             if result != UNKNOWN:
                 return result
 
+    # talosctl: strip global connection flags (-n nodes, -e endpoints, etc.)
+    # first, then re-check the global table. Without this, `talosctl -n 1.2.3.4
+    # get routes` fails to match a `talosctl get` prefix and falls to unknown.
+    if tokens[0] == "talosctl":
+        tokens = _strip_talosctl_global_flags(tokens)
+        if global_table:
+            result = _prefix_match(tokens, global_table)
+            if result != UNKNOWN:
+                return result
+
     # --- Phase 2: Flag classifiers (built-in opinions) ---
     action = _classify_find(
         tokens,
@@ -908,6 +918,72 @@ def _strip_flux_global_flags(tokens: list[str]) -> list[str]:
                 return tokens
             i += 1
         elif tok in _FLUX_BOOLEAN_FLAGS:
+            i += 1
+        elif tok.startswith("-"):
+            return tokens
+        else:
+            result.extend(tokens[i:])
+            break
+    return result
+
+
+_TALOSCTL_SUBCOMMANDS = {
+    "apply-config", "bootstrap", "cgroups", "cluster", "completion", "config",
+    "conformance", "containers", "copy", "dashboard", "debug", "dmesg", "edit",
+    "etcd", "events", "gen", "get", "health", "help", "image", "inject",
+    "inspect", "kubeconfig", "list", "logs", "machineconfig", "memory", "meta",
+    "mounts", "netstat", "patch", "pcap", "processes", "read", "reboot", "reset",
+    "restart", "rollback", "rotate-ca", "service", "shutdown", "stats", "support",
+    "time", "upgrade", "upgrade-k8s", "usage", "validate", "version", "wipe",
+}
+
+# talosctl global (persistent) flags that take a value and precede the subcommand.
+_TALOSCTL_VALUE_FLAGS = {
+    "-e", "--endpoints",
+    "-n", "--nodes",
+    "-c", "--cluster",
+    "--context",
+    "--talosconfig",
+}
+
+_TALOSCTL_VALUE_FLAG_PREFIXES = (
+    "-e=", "--endpoints=",
+    "-n=", "--nodes=",
+    "-c=", "--cluster=",
+    "--context=",
+    "--talosconfig=",
+)
+
+
+def _strip_talosctl_global_flags(tokens: list[str]) -> list[str]:
+    """Strip known talosctl global connection flags before the subcommand.
+
+    talosctl takes persistent flags (-n/--nodes, -e/--endpoints, --context,
+    etc.) before the subcommand, so `talosctl -n 1.2.3.4 get routes` otherwise
+    fails to match a `talosctl get` prefix. Mirrors _strip_kubectl_global_flags:
+    unknown or malformed pre-subcommand flags fail closed by returning the
+    original token stream, leaving classification on the `unknown` path.
+    """
+    result = [tokens[0]]
+    i = 1
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok == "--":
+            if i + 1 >= len(tokens):
+                return tokens
+            result.extend(tokens[i + 1:])
+            break
+        if tok in _TALOSCTL_VALUE_FLAGS:
+            if i + 1 >= len(tokens):
+                return tokens
+            value = tokens[i + 1]
+            if value.startswith("-") or value in _TALOSCTL_SUBCOMMANDS:
+                return tokens
+            i += 2
+        elif any(tok.startswith(prefix) for prefix in _TALOSCTL_VALUE_FLAG_PREFIXES):
+            _, value = tok.split("=", 1)
+            if not value or value in _TALOSCTL_SUBCOMMANDS:
+                return tokens
             i += 1
         elif tok.startswith("-"):
             return tokens

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -419,6 +419,58 @@ class TestClassifyTokens:
             tokens, global_table=self._flux_table(), builtin_table=_FULL,
         ) == "unknown"
 
+    # talosctl — global connection flags stripped before global-table match.
+    # talosctl has no built-in classifier; the user config supplies the
+    # taxonomy, so these go through the global_table after stripping.
+    def _talos_table(self):
+        return build_user_table({
+            "filesystem_read": ["talosctl get", "talosctl read", "talosctl dmesg"],
+            "process_signal": ["talosctl reboot", "talosctl reset"],
+            "network_write": ["talosctl apply-config"],
+        })
+
+    @pytest.mark.parametrize("tokens,expected", [
+        (["talosctl", "-n", "1.2.3.4", "get", "routes"], "filesystem_read"),
+        (["talosctl", "--nodes=1.2.3.4", "dmesg"], "filesystem_read"),
+        (["talosctl", "-e", "1.2.3.4", "-n", "5.6.7.8", "read", "/proc/cmdline"], "filesystem_read"),
+        (["talosctl", "--context", "prod", "get", "members"], "filesystem_read"),
+        (["talosctl", "get", "routes"], "filesystem_read"),
+    ])
+    def test_talosctl_global_flags_stripped_for_reads(self, tokens, expected):
+        assert classify_tokens(
+            tokens, global_table=self._talos_table(), builtin_table=_FULL,
+        ) == expected
+
+    @pytest.mark.parametrize("tokens,expected", [
+        # Safety: stripping must not weaken — dangerous subcommands still match.
+        (["talosctl", "-n", "1.2.3.4", "reboot"], "process_signal"),
+        (["talosctl", "--nodes=1.2.3.4", "reset"], "process_signal"),
+        (["talosctl", "-n", "1.2.3.4", "apply-config", "-f", "c.yaml"], "network_write"),
+    ])
+    def test_talosctl_global_flags_preserve_dangerous(self, tokens, expected):
+        assert classify_tokens(
+            tokens, global_table=self._talos_table(), builtin_table=_FULL,
+        ) == expected
+
+    @pytest.mark.parametrize("tokens", [
+        ["talosctl", "-n"],                       # value flag without value
+        ["talosctl", "-n", "get", "routes"],      # value is a subcommand
+        ["talosctl", "--nodes="],                 # empty =joined value
+        ["talosctl", "--unknown-global", "get"],  # unrecognized pre-subcommand flag
+    ])
+    def test_talosctl_malformed_global_flags_fail_closed(self, tokens):
+        assert classify_tokens(
+            tokens, global_table=self._talos_table(), builtin_table=_FULL,
+        ) == "unknown"
+
+    def test_talosctl_global_table_checked_after_global_flags(self):
+        table = build_user_table({"git_safe": ["talosctl custom-read"]})
+        assert classify_tokens(
+            ["talosctl", "-n", "1.2.3.4", "custom-read"],
+            global_table=table,
+            builtin_table=_FULL,
+        ) == "git_safe"
+
     # find — special case
     def test_find_read(self):
         assert _ct(["find", ".", "-name", "*.py"]) == "filesystem_read"


### PR DESCRIPTION
Mirrors `_strip_kubectl_global_flags` (#67/#68).

Adds `_strip_talosctl_global_flags()` in `taxonomy.py` — value flags `-n/--nodes`, `-e/--endpoints`, `-c/--cluster`, `--context`, `--talosconfig` (+ `--flag=value` forms), `--` separator, fail-closed on unknown/malformed pre-subcommand flags and on a flag-value that is itself a subcommand. Called in `classify_tokens()` after the git block to re-check the global table on the stripped tokens.

talosctl has no built-in classifier; the user config supplies the taxonomy, so this is a Phase-1 strip like git (not a Phase-2 classifier like kubectl).

Safety preserved: `talosctl -n <ip> reboot` still classifies as the dangerous subcommand. +13 tests in `tests/test_taxonomy.py` mirroring the kubectl global-flag tests.

Closes #86.
