### PR TITLE
feat: strip flux global flags before subcommand classification

### DIFF
--- a/src/nah/taxonomy.py
+++ b/src/nah/taxonomy.py
@@ -523,6 +523,16 @@ def classify_tokens(
             if result != UNKNOWN:
                 return result
 
+    # flux: strip kubeconfig-style global flags (-n namespace, --context, etc.)
+    # first, then re-check the global table. Without this, `flux -n flux-system
+    # get kustomizations` fails to match a `flux get` prefix and falls to unknown.
+    if tokens[0] == "flux":
+        tokens = _strip_flux_global_flags(tokens)
+        if global_table:
+            result = _prefix_match(tokens, global_table)
+            if result != UNKNOWN:
+                return result
+
     # --- Phase 2: Flag classifiers (built-in opinions) ---
     action = _classify_find(
         tokens,
@@ -829,6 +839,75 @@ def _strip_kubectl_global_flags(tokens: list[str]) -> list[str]:
                 return tokens
             i += 1
         elif tok in _KUBECTL_BOOLEAN_FLAGS:
+            i += 1
+        elif tok.startswith("-"):
+            return tokens
+        else:
+            result.extend(tokens[i:])
+            break
+    return result
+
+
+_FLUX_SUBCOMMANDS = {
+    "bootstrap", "build", "check", "completion", "create", "debug", "delete",
+    "diff", "envsubst", "events", "export", "get", "help", "install", "list",
+    "logs", "migrate", "pull", "push", "reconcile", "resume", "stats", "suspend",
+    "tag", "trace", "tree", "uninstall", "version",
+}
+
+# flux global (persistent) flags that take a value and precede the subcommand.
+_FLUX_VALUE_FLAGS = {
+    "-n", "--namespace", "--as", "--as-group", "--as-uid", "--as-user-extra",
+    "--cache-dir", "--certificate-authority", "--client-certificate",
+    "--client-key", "--cluster", "--context", "--kube-api-burst",
+    "--kube-api-qps", "--kubeconfig", "--server", "--timeout",
+    "--tls-server-name", "--token", "--user",
+}
+
+_FLUX_VALUE_FLAG_PREFIXES = (
+    "-n=", "--namespace=", "--as=", "--as-group=", "--as-uid=", "--as-user-extra=",
+    "--cache-dir=", "--certificate-authority=", "--client-certificate=",
+    "--client-key=", "--cluster=", "--context=", "--kube-api-burst=",
+    "--kube-api-qps=", "--kubeconfig=", "--server=", "--timeout=",
+    "--tls-server-name=", "--token=", "--user=",
+)
+
+_FLUX_BOOLEAN_FLAGS = {
+    "--disable-compression", "--insecure-skip-tls-verify", "--verbose", "--help",
+}
+
+
+def _strip_flux_global_flags(tokens: list[str]) -> list[str]:
+    """Strip known flux global flags before the subcommand.
+
+    flux takes kubeconfig-style persistent flags (-n/--namespace, --context,
+    --kubeconfig, etc.) before the subcommand, so `flux -n flux-system get
+    kustomizations` otherwise fails to match a `flux get` prefix. Mirrors
+    _strip_kubectl_global_flags: unknown or malformed pre-subcommand flags fail
+    closed by returning the original token stream.
+    """
+    result = [tokens[0]]
+    i = 1
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok == "--":
+            if i + 1 >= len(tokens):
+                return tokens
+            result.extend(tokens[i + 1:])
+            break
+        if tok in _FLUX_VALUE_FLAGS:
+            if i + 1 >= len(tokens):
+                return tokens
+            value = tokens[i + 1]
+            if value.startswith("-") or value in _FLUX_SUBCOMMANDS:
+                return tokens
+            i += 2
+        elif any(tok.startswith(prefix) for prefix in _FLUX_VALUE_FLAG_PREFIXES):
+            _, value = tok.split("=", 1)
+            if not value or value in _FLUX_SUBCOMMANDS:
+                return tokens
+            i += 1
+        elif tok in _FLUX_BOOLEAN_FLAGS:
             i += 1
         elif tok.startswith("-"):
             return tokens

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -376,6 +376,49 @@ class TestClassifyTokens:
             profile="none",
         ) == "container_read"
 
+    # flux — kubeconfig-style global flags stripped before global-table match.
+    # flux has no built-in classifier; the user config supplies the taxonomy.
+    def _flux_table(self):
+        return build_user_table({
+            "filesystem_read": ["flux get", "flux list", "flux logs"],
+            "network_write": ["flux create", "flux suspend"],
+            "container_destructive": ["flux delete", "flux uninstall"],
+        })
+
+    @pytest.mark.parametrize("tokens,expected", [
+        (["flux", "-n", "flux-system", "get", "kustomizations"], "filesystem_read"),
+        (["flux", "--namespace=apps", "list", "all"], "filesystem_read"),
+        (["flux", "--context", "prod", "-n", "apps", "logs"], "filesystem_read"),
+        (["flux", "--insecure-skip-tls-verify", "get", "sources"], "filesystem_read"),
+        (["flux", "get", "kustomizations"], "filesystem_read"),
+    ])
+    def test_flux_global_flags_stripped_for_reads(self, tokens, expected):
+        assert classify_tokens(
+            tokens, global_table=self._flux_table(), builtin_table=_FULL,
+        ) == expected
+
+    @pytest.mark.parametrize("tokens,expected", [
+        # Safety: stripping must not weaken — destructive subcommands still match.
+        (["flux", "-n", "flux-system", "delete", "kustomization", "app"], "container_destructive"),
+        (["flux", "--namespace=apps", "uninstall"], "container_destructive"),
+        (["flux", "-n", "apps", "suspend", "kustomization", "app"], "network_write"),
+    ])
+    def test_flux_global_flags_preserve_dangerous(self, tokens, expected):
+        assert classify_tokens(
+            tokens, global_table=self._flux_table(), builtin_table=_FULL,
+        ) == expected
+
+    @pytest.mark.parametrize("tokens", [
+        ["flux", "-n"],                          # value flag without value
+        ["flux", "-n", "get", "sources"],        # value is a subcommand
+        ["flux", "--namespace="],                # empty =joined value
+        ["flux", "--unknown-global", "get"],     # unrecognized pre-subcommand flag
+    ])
+    def test_flux_malformed_global_flags_fail_closed(self, tokens):
+        assert classify_tokens(
+            tokens, global_table=self._flux_table(), builtin_table=_FULL,
+        ) == "unknown"
+
     # find — special case
     def test_find_read(self):
         assert _ct(["find", ".", "-name", "*.py"]) == "filesystem_read"


### PR DESCRIPTION
Same class as kubectl #67 / talosctl (#86). Adds `_strip_flux_global_flags()` mirroring the kubectl/talosctl idiom, called in `classify_tokens()` after the git block. Covers flux's kubeconfig-style value flags (`-n/--namespace`, `--context`, `--kubeconfig`, `--cluster`, `--timeout`, `--token`, …) and boolean globals (`--insecure-skip-tls-verify`, `--verbose`, …); fail-closed.

Safety preserved: `flux -n <ns> delete …` still classifies destructive. +12 tests.

Closes #87.
