### PR TITLE
feat: add ask_fallback: defer — pass unresolved asks to the agent (#91)

### DIFF
--- a/src/nah/codex_run.py
+++ b/src/nah/codex_run.py
@@ -349,7 +349,9 @@ def build_codex_launch(
         env.pop(_PROBE_DELAY_ENV, None)
     headless_ask_fallback = ""
     if headless:
-        headless_ask_fallback = getattr(effective_cfg, "ask_fallback", "") or "block"
+        raw_fallback = getattr(effective_cfg, "ask_fallback", "") or "block"
+        # Non-interactive headless mode cannot defer — coerce to block
+        headless_ask_fallback = "block" if raw_fallback == "defer" else raw_fallback
         env[_HEADLESS_ENV] = "1"
         env[_HEADLESS_ASK_FALLBACK_ENV] = headless_ask_fallback
         env[_HEADLESS_SANDBOX_ENV] = sandbox_mode

--- a/src/nah/config.py
+++ b/src/nah/config.py
@@ -16,7 +16,7 @@ _CONFIG_DIR = nah_config_dir()
 _GLOBAL_CONFIG = os.path.join(_CONFIG_DIR, "config.yaml")
 _PROJECT_CONFIG_NAME = ".nah.yaml"
 _PRESET_ENV = "NAH_PRESET"
-_ASK_FALLBACKS = {"allow", "block"}
+_ASK_FALLBACKS = {"allow", "block", "defer"}
 
 
 @dataclass
@@ -403,7 +403,7 @@ def _normalize_ask_fallback(raw, *, context: str) -> str:
     if raw in _ASK_FALLBACKS:
         return raw
     raise ConfigError(
-        f"{context}.ask_fallback must be 'allow' or 'block', got {raw!r}"
+        f"{context}.ask_fallback must be 'allow', 'block', or 'defer', got {raw!r}"
     )
 
 

--- a/src/nah/hook.py
+++ b/src/nah/hook.py
@@ -923,7 +923,7 @@ def _apply_ask_fallback(decision: dict, cfg=None) -> dict:
 
         cfg = get_config()
     mode = getattr(cfg, "ask_fallback", "")
-    if mode not in (taxonomy.ALLOW, taxonomy.BLOCK):
+    if mode not in (taxonomy.ALLOW, taxonomy.BLOCK, "defer"):
         return decision
 
     original_reason = str(decision.get("reason", "") or "")
@@ -934,6 +934,14 @@ def _apply_ask_fallback(decision: dict, cfg=None) -> dict:
         "to": mode,
         "reason": original_reason,
     }
+
+    # Defer: let the agent's own permission layer decide
+    # The decision is logged but not emitted (pass-through)
+    if mode == "defer":
+        decision["decision"] = taxonomy.ASK
+        decision["reason"] = f"ask fallback deferred to agent: {original_reason or 'review required'}"
+        return decision
+
     decision["decision"] = mode
     verb = "blocked" if mode == taxonomy.BLOCK else "allowed"
     review = original_reason or "review required"


### PR DESCRIPTION
## What

Add a third `ask_fallback` value: `defer`.

On an unresolved `ask`, `defer` makes the hook emit nothing (same pass-through as silent allow) so the agent's own permission layer decides. The decision is still logged with defer metadata.

## Why

From [#91](https://github.com/manuelschipper/nah/issues/91): With `active_allow: true` + `ask_fallback: defer`, the layering becomes:
- nah-safe → allow
- ambiguous → **defer** (agent decides)
- dangerous → block

`defer` is meaningful only where the agent has a permission layer to fall through to.

## How

### `config.py`
- Add `defer` to `_ASK_FALLBACKS`
- Update error message to include `defer`

### `hook.py`
- `_apply_ask_fallback`: when mode is `defer`, keep decision as `ASK` (pass-through) instead of converting to `ALLOW`/`BLOCK`
- Log defer metadata for audit trail

### `codex_run.py`
- Non-interactive headless mode coerces `defer → block` (no permission layer to fall through to)

## Example Config

```yaml
targets:
  claude:
    ask_fallback: defer
    active_allow: true
```

## Behavior

| Scenario | ask_fallback | Result |
|----------|--------------|--------|
| Safe action | any | allow (by nah) |
| Ambiguous action | allow | allow (forced) |
| Ambiguous action | block | block (forced) |
| Ambiguous action | **defer** | **ask** (agent decides) |
| Dangerous action | any | block (by nah) |
| Headless + defer | defer | block (coerced) |

Closes #91

Signed-off-by: zsxh1990 <zsxh1990@users.noreply.github.com>