### PR TITLE
feat: surface calling agent in `nah log` (display + --agent filter)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ nah types                # list all 43 action types with default policies
 nah log                  # show recent hook decisions
 nah log --blocks         # show only blocked decisions
 nah log --asks           # show only ask decisions
+nah log --agent codex    # show only one agent's decisions (claude, codex)
 nah log --llm            # show only decisions with LLM metadata
 nah status codex         # inspect Codex approval-memory/MCP preflight state
 nah setup codex          # install or fix supported Codex setup state

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`nah log` now surfaces the calling agent.** Each entry already recorded which
+  agent produced the action (`claude`, `codex`, or `terminal` for the interactive
+  bash guard); the human-readable output now shows it as a column and a new
+  `--agent <name>` flag filters by it (composes with `--blocks`/`--asks`/`--tool`).
+  `--json` output is unchanged.
+
 ## [0.11.0] - 2026-07-19
 
 ### Added

--- a/src/nah/cli.py
+++ b/src/nah/cli.py
@@ -1704,6 +1704,9 @@ def cmd_log(args: argparse.Namespace) -> None:
     tool = getattr(args, "tool", None)
     if tool:
         filters["tool"] = tool
+    agent = getattr(args, "agent", None)
+    if agent:
+        filters["agent"] = agent.lower()
 
     limit = getattr(args, "limit", 50)
     json_output = getattr(args, "json", False)
@@ -1741,7 +1744,8 @@ def cmd_log(args: argparse.Namespace) -> None:
             marker = "  "
 
         state = f" {execution_state}" if execution_state else ""
-        line = f"{ts}  {marker}{decision:<5}{state:<17}  {tool_name:<5}  {summary}"
+        agent_name = entry.get("agent", "")
+        line = f"{ts}  {marker}{decision:<5}{state:<17}  {agent_name:<6}  {tool_name:<5}  {summary}"
         if reason:
             line += f"  ({reason})"
         if total_ms != "":
@@ -2064,6 +2068,7 @@ def main():
     log_parser.add_argument("--llm", action="store_true", help="Show only entries with LLM metadata")
     log_parser.add_argument("--classified", action="store_true", help="Show only entries with a Layer-1 classify pass")
     log_parser.add_argument("--tool", default=None, help="Filter by tool name (Bash, Read, Write, ...)")
+    log_parser.add_argument("--agent", default=None, help="Filter by agent (claude, codex, terminal)")
     log_parser.add_argument("-n", "--limit", type=int, default=50, help="Number of entries (default: 50)")
     log_parser.add_argument("--json", action="store_true", help="Output as JSON lines")
 

--- a/src/nah/log.py
+++ b/src/nah/log.py
@@ -319,6 +319,8 @@ def read_log(filters: dict | None = None, limit: int = 50) -> list[dict]:
                     continue
                 if "tool" in filters and entry.get("tool") != filters["tool"]:
                     continue
+                if "agent" in filters and entry.get("agent") != filters["agent"]:
+                    continue
                 if filters.get("llm") and not _entry_has_llm(entry):
                     continue
                 if filters.get("classified") and not _entry_has_classify_pass(entry):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -351,6 +351,40 @@ class TestCmdLog:
         assert llm_reason in out
         assert f"LLM detail (review): {llm_detail}" in out
 
+    def test_human_output_shows_agent_column(self, capsys):
+        from nah.cli import cmd_log
+
+        entry = {
+            "ts": "2026-04-29T13:27:48.000+00:00",
+            "agent": "codex",
+            "tool": "Bash",
+            "decision": "allow",
+            "reason": "",
+            "input": "git status",
+            "ms": 1,
+        }
+
+        with patch("nah.log.read_log", return_value=[entry]):
+            cmd_log(argparse.Namespace(
+                blocks=False, asks=False, llm=False,
+                tool=None, agent=None, limit=5, json=False,
+            ))
+
+        out = capsys.readouterr().out
+        assert "codex" in out
+
+    def test_agent_filter_passed_to_read_log_lowercased(self):
+        from nah.cli import cmd_log
+
+        with patch("nah.log.read_log", return_value=[]) as mock_read:
+            cmd_log(argparse.Namespace(
+                blocks=False, asks=False, llm=False,
+                tool=None, agent="Codex", limit=5, json=False,
+            ))
+
+        _, kwargs = mock_read.call_args
+        assert kwargs["filters"]["agent"] == "codex"
+
 
 class TestCmdConfig:
     def test_config_presets_lists_names(self, tmp_path, capsys):

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -375,6 +375,19 @@ class TestReadLog:
         assert len(entries) == 1
         assert entries[0]["tool"] == "Bash"
 
+    def test_filter_by_agent(self, tmp_path):
+        log.log_decision({"decision": "allow", "agent": "claude"})
+        log.log_decision({"decision": "allow", "agent": "codex"})
+        entries = log.read_log(filters={"agent": "codex"})
+        assert len(entries) == 1
+        assert entries[0]["agent"] == "codex"
+
+    def test_filter_by_agent_unknown_returns_empty(self, tmp_path):
+        log.log_decision({"decision": "allow", "agent": "claude"})
+        log.log_decision({"decision": "allow", "agent": "codex"})
+        entries = log.read_log(filters={"agent": "gemini"})
+        assert entries == []
+
     def test_filter_by_llm(self, tmp_path):
         log.log_decision({"decision": "allow", "tool": "Bash"})
         log.log_decision({"decision": "ask", "tool": "Bash", "llm": {"provider": "openrouter"}})


### PR DESCRIPTION
## What

`nah log` now shows which agent produced each decision and can filter by it.

Every log entry already carries a top-level `agent` field (`claude`, `codex`, or `terminal` for the interactive bash guard), set in `build_entry`. But the `nah log` viewer neither displayed nor filtered on it — the only way to tell agents apart was `nah log --json` plus manual parsing.

## Changes

- **Display**: add a fixed-width agent column to the human-readable output.
- **Filter**: new `--agent <name>` flag (case-insensitive) that composes with `--blocks` / `--asks` / `--tool`. Mirrors the existing free-form `--tool` flag, so it stays forward-compatible with future agents.
- `--json` output is unchanged (it already emits `agent`).
- Tests for the `read_log` agent filter and the CLI display/filter.
- CHANGELOG + AGENTS.md quick-reference updated.

## Not included

No change to agent *detection* — `detect_agent` remains a stub returning `claude`; codex/terminal entries are tagged by their own hook paths. This PR only surfaces data that is already recorded.

## Verification

`pytest tests/test_log.py tests/test_cli.py` — green. Manually confirmed the column renders and `--agent`/`--blocks` compose against a real `~/.config/nah/nah.log`.
