### PR TITLE
feat: expand static for-loop globs at classify time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **For-loops over static globs are now classified instead of asking.**
+  `for f in docs/*.md; do cat "$f"; done` used to ask with "for-loop variable
+  comes from a dynamic item list" regardless of the body. When the item list
+  is static literals and/or glob patterns (no `$`, backticks, or command
+  substitution), the globs are expanded at classify time against the tracked
+  shell cwd and the loop body is classified per expanded file — a read-only
+  body over project files now allows, while write/network bodies keep their
+  normal per-file decision. Expansion fails closed: unknown cwd (e.g. after
+  `cd "$dir"`), a glob matching nothing, more than 128 matches, or a matched
+  file name that is itself unsafe to expand (leading `-`, whitespace, glob
+  chars) all keep the ask. Brace expansion (`{1..3}`, `{a,b}`) is unchanged.
+
 ## [0.11.0] - 2026-07-19
 
 ### Added

--- a/src/nah/bash.py
+++ b/src/nah/bash.py
@@ -1,5 +1,6 @@
 """Bash command classifier — tokenize, decompose, classify, compose."""
 
+import glob as _glob
 import os.path
 import re
 import shlex
@@ -35,6 +36,10 @@ _PYTHON_ENV_RISK_VARS = frozenset({
 _CONTROL_FLOW_OPENERS = frozenset({"for", "while", "until", "if"})
 _CONTROL_FLOW_TERMINATORS = {"for": "done", "while": "done", "until": "done", "if": "fi"}
 _LOOP_VALUE_GLOB_CHARS = frozenset("*?[{}")
+# Chars that trigger classify-time glob expansion of for-loop items. Braces
+# are deliberately excluded: {a,b}/{1..3} is brace expansion, not globbing,
+# and stays on the dynamic-item-list ask path.
+_LOOP_GLOB_EXPAND_CHARS = frozenset("*?[")
 _SHELL_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
@@ -199,9 +204,11 @@ def classify_command(command: str) -> ClassifyResult:
                project_table=project_table, user_actions=user_actions,
                trust_project=trust_project)
 
-    # Decompose each raw stage into classified stages
+    # Decompose each raw stage into classified stages. The process cwd is the
+    # tool call's cwd, so top-level for-loop globs may expand against it;
+    # nested/unwrapped parses keep the fail-closed default (no expansion).
     try:
-        stages = _raw_stages_to_stages(raw_stages)
+        stages = _raw_stages_to_stages(raw_stages, glob_cwd=os.getcwd())
     except ValueError as exc:
         result.final_decision = taxonomy.ASK
         detail = str(exc) or "shlex error"
@@ -1233,9 +1240,20 @@ def _raw_stage_to_stages(
     )
 
 
-def _raw_stages_to_stages(raw_stages: list[tuple[str, str]]) -> list[Stage]:
-    """Convert raw shell stages into classifier stages, unwrapping safe control flow."""
+def _raw_stages_to_stages(
+    raw_stages: list[tuple[str, str]],
+    glob_cwd: str | None = None,
+) -> list[Stage]:
+    """Convert raw shell stages into classifier stages, unwrapping safe control flow.
+
+    ``glob_cwd`` is the directory used for classify-time expansion of static
+    globs in for-loop item lists. ``None`` (the default) disables expansion,
+    which keeps every nested/unwrapped call site fail-closed; only the
+    top-level ``classify_command`` opts in with the process cwd.
+    """
     stages: list[Stage] = []
+    cwd = glob_cwd
+    cwd_unknown = glob_cwd is None
     i = 0
     while i < len(raw_stages):
         stage_str, op = raw_stages[i]
@@ -1244,24 +1262,54 @@ def _raw_stages_to_stages(raw_stages: list[tuple[str, str]]) -> list[Stage]:
             i += 1
             continue
 
+        effective_cwd = None if cwd_unknown else cwd
         keyword = _leading_shell_keyword(stripped)
         control: tuple[list[Stage], int] | None = None
         if keyword == "for":
-            control = _consume_for_loop(raw_stages, i)
+            control = _consume_for_loop(raw_stages, i, glob_cwd=effective_cwd)
         elif keyword in {"while", "until"}:
-            control = _consume_while_until(raw_stages, i, keyword)
+            control = _consume_while_until(raw_stages, i, keyword, glob_cwd=effective_cwd)
         elif keyword == "if":
-            control = _consume_if(raw_stages, i)
+            control = _consume_if(raw_stages, i, glob_cwd=effective_cwd)
 
         if control is not None:
             control_stages, next_i = control
+            cwd, cwd_unknown = _track_glob_cwd(control_stages, cwd, cwd_unknown)
             stages.extend(control_stages)
             i = next_i
             continue
 
-        stages.extend(_raw_stage_to_stages(stage_str, op))
+        new_stages = _raw_stage_to_stages(stage_str, op)
+        cwd, cwd_unknown = _track_glob_cwd(new_stages, cwd, cwd_unknown)
+        stages.extend(new_stages)
         i += 1
     return stages
+
+
+def _track_glob_cwd(
+    stages: list[Stage],
+    cwd: str | None,
+    cwd_unknown: bool,
+) -> tuple[str | None, bool]:
+    """Track the shell cwd used for classify-time glob expansion.
+
+    Mirrors the sequential cwd tracking in ``classify_command`` but is
+    stricter: a cwd-changing stage that is not sequenced with ``&&``/``;``
+    (e.g. behind ``||`` or a pipe, where whether it ran is undecidable)
+    makes the cwd unknown, which disables glob expansion for the rest of
+    the command.
+    """
+    if cwd_unknown or cwd is None:
+        return cwd, True
+    for stage in stages:
+        if not _stage_can_change_cwd(stage):
+            continue
+        if stage.operator not in {"&&", ";", ""}:
+            return cwd, True
+        cwd, cwd_unknown = _stage_shell_cwd_update(stage, cwd, cwd_unknown)
+        if cwd_unknown:
+            return cwd, True
+    return cwd, cwd_unknown
 
 
 def _leading_shell_keyword(stage_str: str) -> str:
@@ -1396,21 +1444,90 @@ def _find_control_flow_body(
     return None
 
 
+def _safe_literal_loop_value(value: str) -> bool:
+    return not (
+        not value
+        or value.startswith("-")
+        or any(ch.isspace() for ch in value)
+        or any(ch in value for ch in _LOOP_VALUE_GLOB_CHARS)
+        or "$" in value
+        or "`" in value
+        or _PSUB_PREFIX in value
+    )
+
+
 def _safe_literal_loop_values(values: list[str]) -> bool:
     if not values or len(values) > _MAX_CONTROL_FLOW_EXPANSIONS:
         return False
+    return all(_safe_literal_loop_value(value) for value in values)
+
+
+def _expand_loop_glob_values(
+    values: list[str],
+    glob_cwd: str | None,
+) -> tuple[list[str] | None, str]:
+    """Expand static glob patterns in a for-loop item list at classify time.
+
+    Returns ``(expanded_values, "")`` on success, or ``(None, reason)`` when
+    the list cannot be expanded safely — an empty reason means "fall back to
+    the generic dynamic-item-list ask".
+
+    Expansion happens at classification time, immediately before execution;
+    files created or renamed in between are outside nah's deterministic model
+    (the same TOCTOU caveat as every other path check nah performs). Every
+    expanded name flows through the normal per-value body classification, so
+    sensitive paths, project boundaries and symlinks are checked there.
+    """
+    if glob_cwd is None:
+        return None, ""
+    if not values or len(values) > _MAX_CONTROL_FLOW_EXPANSIONS:
+        return None, ""
+    expanded: list[str] = []
     for value in values:
         if (
             not value
             or value.startswith("-")
             or any(ch.isspace() for ch in value)
-            or any(ch in value for ch in _LOOP_VALUE_GLOB_CHARS)
+            or "{" in value
+            or "}" in value
             or "$" in value
             or "`" in value
             or _PSUB_PREFIX in value
         ):
-            return False
-    return True
+            return None, ""
+        if not any(ch in value for ch in _LOOP_GLOB_EXPAND_CHARS):
+            expanded.append(value)
+            continue
+        pattern = os.path.expanduser(value)
+        try:
+            if os.path.isabs(pattern):
+                matches = sorted(_glob.glob(pattern, recursive=False))
+            else:
+                matches = sorted(
+                    _glob.glob(pattern, root_dir=glob_cwd, recursive=False)
+                )
+        except (OSError, ValueError):
+            # glob delegates to os.scandir; a failure (permissions, bad
+            # pattern) means we cannot prove what the loop iterates over —
+            # fall through to the generic dynamic-item-list ask.
+            return None, ""
+        if not matches:
+            # Bash would iterate the literal unmatched pattern once;
+            # classifying that literal proves nothing about the files that
+            # may exist at run time, so ask.
+            return None, "for-loop glob matched no files"
+        for match in matches:
+            if not _safe_literal_loop_value(match):
+                return None, "for-loop glob matched an unsafe file name"
+        expanded.extend(matches)
+        if len(expanded) > _MAX_CONTROL_FLOW_EXPANSIONS:
+            return None, (
+                "for-loop glob expands to more than "
+                f"{_MAX_CONTROL_FLOW_EXPANSIONS} items"
+            )
+    if not expanded:
+        return None, ""
+    return expanded, ""
 
 
 def _stages_reference_var(stages: list[Stage], name: str) -> bool:
@@ -1479,7 +1596,11 @@ def _expand_loop_body_for_values(
     return expanded
 
 
-def _consume_for_loop(raw_stages: list[tuple[str, str]], start: int) -> tuple[list[Stage], int] | None:
+def _consume_for_loop(
+    raw_stages: list[tuple[str, str]],
+    start: int,
+    glob_cwd: str | None = None,
+) -> tuple[list[Stage], int] | None:
     parsed = _find_control_flow_body(raw_stages, start, "do", "done")
     if parsed is None:
         return None
@@ -1507,7 +1628,7 @@ def _consume_for_loop(raw_stages: list[tuple[str, str]], start: int) -> tuple[li
     name = header_tokens[0]
     values = header_tokens[2:]
     try:
-        body_stages = _raw_stages_to_stages(body_raw)
+        body_stages = _raw_stages_to_stages(body_raw, glob_cwd)
     except ValueError:
         return [_control_flow_guard_stage("for", "unparseable for-loop body", raw_parts)], next_i
     if not body_stages:
@@ -1539,7 +1660,28 @@ def _consume_for_loop(raw_stages: list[tuple[str, str]], start: int) -> tuple[li
                     body_parts,
                 )
             ], next_i
-        if not _safe_literal_loop_values(values):
+        resolved_values = values if _safe_literal_loop_values(values) else None
+        glob_note: list[Stage] = []
+        if resolved_values is None and any(
+            ch in value for value in values for ch in _LOOP_GLOB_EXPAND_CHARS
+        ):
+            resolved_values, glob_fail_reason = _expand_loop_glob_values(values, glob_cwd)
+            if resolved_values is not None:
+                glob_note = [
+                    Stage(
+                        tokens=["for", name, "in", *values],
+                        operator=";",
+                        action_hint=taxonomy.FILESYSTEM_READ,
+                        action_reason=(
+                            f"for-loop over {len(resolved_values)} glob-expanded files"
+                        ),
+                    )
+                ]
+            elif glob_fail_reason:
+                return guard_stages + [
+                    _control_flow_guard_stage("for", glob_fail_reason, [header])
+                ], next_i
+        if resolved_values is None:
             return guard_stages + [
                 _control_flow_guard_stage(
                     "for",
@@ -1549,8 +1691,9 @@ def _consume_for_loop(raw_stages: list[tuple[str, str]], start: int) -> tuple[li
             ], next_i
         return (
             guard_stages
+            + glob_note
             + body_substitution_guard
-            + _expand_loop_body_for_values(body_stages, name, values, outer_op)
+            + _expand_loop_body_for_values(body_stages, name, resolved_values, outer_op)
         ), next_i
 
     _apply_outer_operator(body_stages, outer_op)
@@ -1561,6 +1704,7 @@ def _consume_while_until(
     raw_stages: list[tuple[str, str]],
     start: int,
     keyword: str,
+    glob_cwd: str | None = None,
 ) -> tuple[list[Stage], int] | None:
     parsed = _find_control_flow_body(raw_stages, start, "do", "done")
     if parsed is None:
@@ -1580,8 +1724,8 @@ def _consume_while_until(
 
     condition_raw = [(header, ";")] if header else []
     try:
-        condition_stages = _raw_stages_to_stages(condition_raw)
-        body_stages = _raw_stages_to_stages(body_raw)
+        condition_stages = _raw_stages_to_stages(condition_raw, glob_cwd)
+        body_stages = _raw_stages_to_stages(body_raw, glob_cwd)
     except ValueError:
         return [_control_flow_guard_stage(keyword, f"unparseable {keyword} body", raw_parts)], next_i
     if not condition_stages or not body_stages:
@@ -1596,7 +1740,11 @@ def _consume_while_until(
     ), next_i
 
 
-def _consume_if(raw_stages: list[tuple[str, str]], start: int) -> tuple[list[Stage], int] | None:
+def _consume_if(
+    raw_stages: list[tuple[str, str]],
+    start: int,
+    glob_cwd: str | None = None,
+) -> tuple[list[Stage], int] | None:
     condition_head = _strip_leading_shell_keyword(raw_stages[start][0], "if")
     if condition_head is None:
         return None
@@ -1665,7 +1813,7 @@ def _consume_if(raw_stages: list[tuple[str, str]], start: int) -> tuple[list[Sta
                     )
                 ], j + 1
             try:
-                stages = _raw_stages_to_stages(executable_raw)
+                stages = _raw_stages_to_stages(executable_raw, glob_cwd)
             except ValueError:
                 return [_control_flow_guard_stage("if", "unparseable if body", raw_parts)], j + 1
             if not stages:
@@ -4250,8 +4398,13 @@ def _unwrap_shell(
                 project_table=project_table, user_actions=user_actions,
                 trust_project=trust_project)
 
+    # The unwrapped shell starts in the outer stage's cwd, so for-loop glob
+    # expansion may use it when it is known; unknown cwd disables expansion.
+    inner_glob_cwd = None
+    if not stage.shell_cwd_unknown:
+        inner_glob_cwd = stage.shell_cwd or os.getcwd()
     try:
-        inner_stages = _raw_stages_to_stages(raw_stages)
+        inner_stages = _raw_stages_to_stages(raw_stages, glob_cwd=inner_glob_cwd)
     except ValueError as exc:
         detail = str(exc) or "shlex error"
         return _obfuscated_result(tokens, f"unparseable inner command ({detail})", user_actions)

--- a/src/nah/messages.py
+++ b/src/nah/messages.py
@@ -130,6 +130,12 @@ def human_reason(
         return _finalize("this shell loop pipes output in a way nah cannot inspect safely")
     if "dynamic item list" in clean_reason.lower():
         return _finalize("this shell loop uses a dynamic item list")
+    if "glob matched no files" in clean_reason.lower():
+        return _finalize("this shell loop's glob matched no files at check time")
+    if "glob expands to more than" in clean_reason.lower():
+        return _finalize("this shell loop expands to more files than nah can inspect")
+    if "glob matched an unsafe file name" in clean_reason.lower():
+        return _finalize("this shell loop matched a file name nah cannot expand safely")
     if "unsupported shell expansion" in clean_reason.lower():
         return _finalize("this shell loop uses shell expansion nah cannot inspect safely")
     if "hidden by shell syntax" in clean_reason.lower():

--- a/tests/test_bash.py
+++ b/tests/test_bash.py
@@ -4029,11 +4029,100 @@ class TestShellControlFlow:
         assert r.final_decision == "block"
         assert r.composition_rule == "sensitive_read | network"
 
-    def test_for_loop_dynamic_values_fail_closed(self, project_root):
+    def test_for_loop_unmatched_glob_fails_closed(self, project_root, monkeypatch):
+        # Static globs expand at classify time; a glob that matches nothing
+        # stays an ask (bash would iterate the literal pattern, and files may
+        # exist by run time — TOCTOU).
+        monkeypatch.chdir(project_root)
         r = classify_command('for f in tests/*.py; do rm "$f"; done')
         assert r.final_decision == "ask"
         assert r.stages[0].action_type == "unknown"
+        assert "glob matched no files" in r.reason
+
+    def test_for_loop_glob_expands_readonly_body(self, project_root, monkeypatch):
+        docs = os.path.join(project_root, "docs")
+        os.makedirs(docs)
+        for name in ("a.md", "b.md"):
+            open(os.path.join(docs, name), "w").close()
+        monkeypatch.chdir(project_root)
+        r = classify_command('for f in docs/*.md; do cat "$f"; done')
+        assert r.final_decision == "allow"
+        assert "glob-expanded files" in r.reason
+        assert any(sr.tokens == ["cat", "docs/a.md"] for sr in r.stages)
+        assert any(sr.tokens == ["cat", "docs/b.md"] for sr in r.stages)
+
+    def test_for_loop_glob_mixed_with_literals(self, project_root, monkeypatch):
+        docs = os.path.join(project_root, "docs")
+        os.makedirs(docs)
+        open(os.path.join(docs, "a.md"), "w").close()
+        open(os.path.join(project_root, "README.md"), "w").close()
+        monkeypatch.chdir(project_root)
+        r = classify_command('for f in README.md docs/*.md; do wc -l "$f"; done')
+        assert r.final_decision == "allow"
+        assert any(sr.tokens == ["wc", "-l", "README.md"] for sr in r.stages)
+        assert any(sr.tokens == ["wc", "-l", "docs/a.md"] for sr in r.stages)
+
+    def test_for_loop_glob_write_body_matches_top_level(self, project_root, monkeypatch):
+        # The expanded body gets the same per-file classification a top-level
+        # command would — the glob adds no leniency of its own.
+        docs = os.path.join(project_root, "docs")
+        os.makedirs(docs)
+        open(os.path.join(docs, "a.md"), "w").close()
+        monkeypatch.chdir(project_root)
+        loop = classify_command('for f in docs/*.md; do rm "$f"; done')
+        top = classify_command("rm docs/a.md")
+        assert loop.final_decision == top.final_decision
+
+    def test_for_loop_glob_unsafe_filename_fails_closed(self, project_root, monkeypatch):
+        open(os.path.join(project_root, "-rf"), "w").close()
+        open(os.path.join(project_root, "ok.txt"), "w").close()
+        monkeypatch.chdir(project_root)
+        r = classify_command('for f in *; do cat "$f"; done')
+        assert r.final_decision == "ask"
+        assert "unsafe file name" in r.reason
+
+    def test_for_loop_glob_whitespace_filename_fails_closed(self, project_root, monkeypatch):
+        open(os.path.join(project_root, "a b.md"), "w").close()
+        monkeypatch.chdir(project_root)
+        r = classify_command('for f in *.md; do cat "$f"; done')
+        assert r.final_decision == "ask"
+        assert "unsafe file name" in r.reason
+
+    def test_for_loop_glob_over_expansion_cap_fails_closed(self, project_root, monkeypatch):
+        many = os.path.join(project_root, "many")
+        os.makedirs(many)
+        for i in range(129):
+            open(os.path.join(many, f"f{i:03d}.txt"), "w").close()
+        monkeypatch.chdir(project_root)
+        r = classify_command('for f in many/*.txt; do cat "$f"; done')
+        assert r.final_decision == "ask"
+        assert "expands to more than" in r.reason
+
+    def test_for_loop_glob_unknown_cwd_fails_closed(self, project_root, monkeypatch):
+        docs = os.path.join(project_root, "docs")
+        os.makedirs(docs)
+        open(os.path.join(docs, "a.md"), "w").close()
+        monkeypatch.chdir(project_root)
+        r = classify_command('cd "$D" && for f in docs/*.md; do cat "$f"; done')
+        assert r.final_decision == "ask"
         assert "dynamic item list" in r.reason
+
+    def test_for_loop_glob_after_cd_expands_in_new_cwd(self, project_root, monkeypatch):
+        docs = os.path.join(project_root, "docs")
+        os.makedirs(docs)
+        open(os.path.join(docs, "a.md"), "w").close()
+        monkeypatch.chdir(project_root)
+        r = classify_command('cd docs && for f in *.md; do cat "$f"; done')
+        assert r.final_decision == "allow"
+        assert any(sr.tokens == ["cat", "a.md"] for sr in r.stages)
+
+    def test_for_loop_glob_in_bash_c_wrapper(self, project_root, monkeypatch):
+        docs = os.path.join(project_root, "docs")
+        os.makedirs(docs)
+        open(os.path.join(docs, "a.md"), "w").close()
+        monkeypatch.chdir(project_root)
+        r = classify_command("bash -c 'for f in docs/*.md; do cat \"$f\"; done'")
+        assert r.final_decision == "allow"
 
     def test_for_loop_brace_expansion_fails_closed(self, project_root):
         r = classify_command('for f in {1..3}; do rm "$f"; done')


### PR DESCRIPTION
## Problem

`for f in docs/*.md; do cat "$f"; done` short-circuits to **"for-loop variable comes from a dynamic item list" → ask**, no matter how safe the body is. In our production logs this was the single largest source of avoidable ask prompts (agents sweep docs/manifests with globbed read-only loops constantly — 23+ asks in 3 days from this pattern alone).

## Approach

The item list is resolved in two steps: literal-only lists keep the existing path, and lists containing **static glob patterns** (no `$`, backticks, or command substitution) are expanded with `glob.glob()` at classify time against the tracked shell cwd, then fed through the existing per-value body expansion — so every expanded file gets the normal path/sensitivity checks, exactly as a literal item would today.

## Fail-closed properties

- Expansion only runs when the shell cwd is deterministically known: a new parse-time cwd tracker mirrors `classify_command`'s but is stricter (`cd "$dir"`, `pushd`/`popd`, or a `||`/pipe-sequenced `cd` disable expansion for the rest of the command). Nested/unwrapped parse sites default to no expansion; only the top-level command and known-cwd `bash -c` unwraps opt in.
- A glob matching **zero files** asks (bash would iterate the literal pattern; files may exist at run time — TOCTOU, noted in the docstring).
- More than `_MAX_CONTROL_FLOW_EXPANSIONS` (128) total items asks — no representative-sample shortcut, since one sample can't prove the rest safe.
- Matched names that are themselves unsafe to expand (leading `-`, whitespace, glob metacharacters) ask — kills option-injection and re-glob risks from hostile file names.
- Brace expansion (`{1..3}`, `{a,b}`) is untouched and stays on the ask path.

The allow reason surfaces as `for-loop over N glob-expanded files`.

## Behavior change called out

`test_for_loop_dynamic_values_fail_closed` asserted that `for f in tests/*.py; do rm "$f"; done` asks with "dynamic item list". It is replaced by tests pinning the new behavior: unmatched globs ask with "glob matched no files", and a matching glob with a write body gets the same per-file decision the top-level command would (`rm docs/a.md` parity — the glob adds no leniency of its own). 10 new tests cover the allow, mixed-list, cap, unsafe-name, unknown-cwd, and `bash -c` cases.

Note: this touches the same `_consume_for_loop` region as #96 (substitution-guard resolution); whichever lands second has a small conflict — happy to rebase either.